### PR TITLE
Add GitHub Actions CI workflow (#88)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Build and test
+        run: ./gradlew build
+
+      - name: Lint
+        run: ./gradlew lintKotlinMain lintKotlinTest


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that runs on pushes to master and PRs
- Runs full build with tests (`./gradlew build`) and lint checks (`./gradlew lintKotlinMain lintKotlinTest`)
- Uses JDK 17 (temurin) with Gradle caching via `gradle/actions/setup-gradle`

## Test plan
- [ ] Workflow triggers on this PR
- [ ] Build and lint steps pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)