### PR TITLE
Update docs for 2.7.0 release (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,20 @@
 
 All notable changes to Common Utils are documented in this file.
 
-## [Unreleased] (2.7.0-dev)
+## [2.7.0] - 2026-04-04
 
 - Migrate artifact publishing from JitPack to Maven Central (group: `com.pambrose.common-utils`)
+- Rename packages from `com.github.pambrose.common.*` to `com.pambrose.common.*`
 - Add Vanniktech Maven Publish plugin for Maven Central publishing with POM metadata and signing
-- Update BOM (`common-utils-bom`) to publish via Maven Central with full POM metadata
-- Disable root project publishing to prevent stale `common-utils:common-utils` artifact
+- Remove `common-utils-bom` module and all BOM dependencies in favor of explicit version refs
+- Disable root project publishing to prevent stale artifacts
 - Remove `jitpack.yml`
-- Update all documentation (README, module READMEs, llms.txt, CLAUDE.md) to reflect Maven Central coordinates
+- Add ~78 new tests across 9 modules (ktor-client-utils, ktor-server-utils, prometheus-utils, guava-utils, service-utils, email-utils, jetty-utils, recaptcha-utils, script-utils-common)
+- Add MockK and ktor-client-mock test dependencies
+- Add GitHub Actions CI workflow for build and lint
+- Update all documentation to reflect Maven Central coordinates
+- Update copyright headers to 2026
+- Upgrade Gradle wrapper to 9.4.1
 - Update dependencies
 
 ## [2.6.2] - 2026-03-16

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,9 @@ These opt-ins are enabled globally:
 
 ### Key Technologies
 
-- Kotlin 2.3.10 with JVM target 17
-- Gradle 9.2.0 with Kotlin DSL
-- JUnit 5 + Kotest for testing
+- Kotlin 2.3.20 with JVM target 17
+- Gradle 9.4.1 with Kotlin DSL
+- Kotest + MockK for testing
 - Kotlinter for linting
 
 ### Package Structure

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Common Utils - Kotlin & Java Utility Library Collection
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/pambrose/common-utils)
-[![Kotlin version](https://img.shields.io/badge/kotlin-2.2.20-red?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.20-red?logo=kotlin)](http://kotlinlang.org)
 [![Maven Central](https://img.shields.io/maven-central/v/com.pambrose.common-utils/core-utils)](https://central.sonatype.com/artifact/com.pambrose.common-utils/core-utils)
 [![ktlint](https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081)](https://pinterest.github.io/ktlint/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
@@ -217,9 +217,9 @@ dependencies {
 
 ## Technology Stack
 
-- **Languages**: Kotlin 2.3.10, Java
-- **Build System**: Gradle with Kotlin DSL
-- **Testing**: JUnit 5, Kotest
+- **Languages**: Kotlin 2.3.20, Java
+- **Build System**: Gradle 9.4.1 with Kotlin DSL
+- **Testing**: Kotest, MockK
 - **Serialization**: Kotlinx.serialization
 - **Concurrency**: Kotlin Coroutines, Guava
 - **Web Frameworks**: Ktor, Jetty

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@
 - Repository: https://github.com/pambrose/common-utils
 - Maven Central: https://central.sonatype.com/namespace/com.pambrose.common-utils
 - License: Apache 2.0
-- Kotlin: 2.3.10, JVM 17
+- Kotlin: 2.3.20, JVM 17
 - Base package: com.pambrose.common.*
 - Install: `implementation("com.pambrose.common-utils:<module>:2.7.0")`
 


### PR DESCRIPTION
## Summary
- Finalize CHANGELOG.md: `[Unreleased]` → `[2.7.0] - 2026-04-04` with complete change list
- Fix Kotlin version badge in README.md (2.2.20 → 2.3.20)
- Update tech stack versions in README.md, CLAUDE.md, and llms.txt (Kotlin 2.3.20, Gradle 9.4.1, Kotest + MockK)

## Test plan
- [ ] CI passes (no code changes, docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)