### PR TITLE
Add Codacy badge, reorder README badges, and reduce Gradle heap size (#90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Common Utils - Kotlin & Java Utility Library Collection
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/pambrose/common-utils)
-[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.20-red?logo=kotlin)](http://kotlinlang.org)
 [![Maven Central](https://img.shields.io/maven-central/v/com.pambrose.common-utils/core-utils)](https://central.sonatype.com/artifact/com.pambrose.common-utils/core-utils)
+[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.20-red?logo=kotlin)](http://kotlinlang.org)
 [![ktlint](https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081)](https://pinterest.github.io/ktlint/)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/5bb4750894844031a55375227acfff6f)](https://app.codacy.com/gh/pambrose/common-utils/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 A collection of utility libraries for Kotlin and Java development.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlin.code.style=official
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.daemon=true
-org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m -Xss10m -Dkotlin.daemon.jvm.options=-Xss10m
+org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m -Xss10m -Dkotlin.daemon.jvm.options=-Xss10m
 # This is a workaround for manes version gradle issue when using coveralls
 # https://github.com/gradle/gradle/issues/26672
 #systemProp.javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl


### PR DESCRIPTION
## Summary
- Reorder README badges to place Maven Central before Kotlin version
- Add Codacy code quality badge
- Reduce Gradle JVM max heap from 2048m to 1g

## Test plan
- [ ] Verify README badges render correctly on GitHub
- [ ] Verify Gradle build still succeeds with reduced heap size

🤖 Generated with [Claude Code](https://claude.com/claude-code)