### PR TITLE
Improve Maven publishing metadata and bump version to 2.7.1 (#91)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,6 @@ All modules use: `com.pambrose.common.*`
 
 ### Version Management
 
-- Project version: "2.7.0" (set in `allprojects` block of root build.gradle.kts)
+- Project version: "2.7.1" (set in `allprojects` block of root build.gradle.kts)
 - Group: "com.pambrose.common-utils"
 - All library versions in `gradle/libs.versions.toml`

--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ This library is available on [Maven Central](https://central.sonatype.com/artifa
 ```kotlin
 dependencies {
     // Include specific modules as needed
-  implementation("com.pambrose.common-utils:core-utils:2.7.0")
-  implementation("com.pambrose.common-utils:json-utils:2.7.0")
-  implementation("com.pambrose.common-utils:ktor-server-utils:2.7.0")
+  implementation("com.pambrose.common-utils:core-utils:2.7.1")
+  implementation("com.pambrose.common-utils:json-utils:2.7.1")
+  implementation("com.pambrose.common-utils:ktor-server-utils:2.7.1")
     // ... other modules
 }
 ```
@@ -210,7 +210,7 @@ dependencies {
     <dependency>
         <groupId>com.pambrose.common-utils</groupId>
         <artifactId>core-utils</artifactId>
-      <version>2.7.0</version>
+      <version>2.7.1</version>
     </dependency>
     <!-- Add other modules as needed -->
 </dependencies>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ val ktlinterLib = libs.plugins.kotlinter.get().toString().split(":").first()
 val versionsLib = libs.plugins.versions.get().toString().split(":").first()
 
 allprojects {
-    extra["versionStr"] = findProperty("overrideVersion")?.toString() ?: "2.7.0"
+    extra["versionStr"] = findProperty("overrideVersion")?.toString() ?: "2.7.1"
     group = "com.pambrose.common-utils"
     version = versionStr
 
@@ -111,7 +111,7 @@ fun Project.configurePublishing() {
 
         pom {
             name.set(project.name)
-            description.set("Kotlin/Java utility library - ${project.name} module")
+            description.set(project.description)
             url.set("https://github.com/pambrose/common-utils")
             licenses {
                 license {
@@ -127,7 +127,7 @@ fun Project.configurePublishing() {
                 }
             }
             scm {
-                connection.set("scm:git:git://github.com/pambrose/common-utils.git")
+                connection.set("scm:git:https://github.com/pambrose/common-utils.git")
                 developerConnection.set("scm:git:ssh://github.com/pambrose/common-utils.git")
                 url.set("https://github.com/pambrose/common-utils")
             }
@@ -137,7 +137,7 @@ fun Project.configurePublishing() {
         signAllPublications()
     }
 
-// Skip signing when no GPG key is provided (e.g., local publishing)
+    // Skip signing when no GPG key is provided (e.g., local publishing)
     tasks.withType<Sign>().configureEach {
         isEnabled = project.findProperty("signingInMemoryKey") != null
     }

--- a/core-utils/build.gradle.kts
+++ b/core-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "core-utils"
+description = "Core Kotlin/Java utilities: string, file, collection, and reflection helpers"
 
 dependencies {
     api(libs.kotlinx.coroutines)

--- a/dropwizard-utils/build.gradle.kts
+++ b/dropwizard-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "dropwizard-utils"
+description = "Dropwizard framework integration utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/email-utils/build.gradle.kts
+++ b/email-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "email-utils"
+description = "Email sending utilities with template support"
 
 plugins {
     alias(libs.plugins.kotlin.serialization)

--- a/exposed-utils/build.gradle.kts
+++ b/exposed-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "exposed-utils"
+description = "Jetbrains Exposed ORM extension utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/grpc-utils/build.gradle.kts
+++ b/grpc-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "grpc-utils"
+description = "gRPC client and server utilities for Kotlin"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/guava-utils/build.gradle.kts
+++ b/guava-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "guava-utils"
+description = "Google Guava extension utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/jetty-utils/build.gradle.kts
+++ b/jetty-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "jetty-utils"
+description = "Embedded Jetty server configuration utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/json-utils/build.gradle.kts
+++ b/json-utils/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-description = "json-utils"
+description = "JSON serialization and deserialization utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/ktor-client-utils/build.gradle.kts
+++ b/ktor-client-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "ktor-client-utils"
+description = "Ktor HTTP client extension utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/ktor-server-utils/build.gradle.kts
+++ b/ktor-server-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "ktor-server-utils"
+description = "Ktor server framework extension utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/llms.txt
+++ b/llms.txt
@@ -2,14 +2,14 @@
 
 > Modular Kotlin/Java utility libraries providing extension functions, DSLs, and helpers for common frameworks. Each module is independently consumable via Maven Central.
 
-- Version: 2.7.0
+- Version: 2.7.1
 - Group: com.pambrose.common-utils
 - Repository: https://github.com/pambrose/common-utils
 - Maven Central: https://central.sonatype.com/namespace/com.pambrose.common-utils
 - License: Apache 2.0
 - Kotlin: 2.3.20, JVM 17
 - Base package: com.pambrose.common.*
-- Install: `implementation("com.pambrose.common-utils:<module>:2.7.0")`
+- Install: `implementation("com.pambrose.common-utils:<module>:2.7.1")`
 
 
 ## Modules

--- a/prometheus-utils/build.gradle.kts
+++ b/prometheus-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "prometheus-utils"
+description = "Prometheus metrics and monitoring utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/recaptcha-utils/build.gradle.kts
+++ b/recaptcha-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "recaptcha-utils"
+description = "Google reCAPTCHA verification utilities"
 
 plugins {
     alias(libs.plugins.kotlin.serialization)

--- a/redis-utils/build.gradle.kts
+++ b/redis-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "redis-utils"
+description = "Redis client extension utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/script-utils-common/build.gradle.kts
+++ b/script-utils-common/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "script-utils-common"
+description = "Common utilities shared across scripting modules"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/script-utils-java/build.gradle.kts
+++ b/script-utils-java/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "script-utils-java"
+description = "Java scripting engine utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/script-utils-kotlin/build.gradle.kts
+++ b/script-utils-kotlin/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "script-utils-kotlin"
+description = "Kotlin scripting engine utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/script-utils-python/build.gradle.kts
+++ b/script-utils-python/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "script-utils-python"
+description = "Python scripting integration utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/service-utils/build.gradle.kts
+++ b/service-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "service-utils"
+description = "Service lifecycle and management utilities"
 
 dependencies {
     implementation(project(":core-utils"))

--- a/zipkin-utils/build.gradle.kts
+++ b/zipkin-utils/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "zipkin-utils"
+description = "Zipkin distributed tracing utilities"
 
 dependencies {
     implementation(project(":core-utils"))


### PR DESCRIPTION
## Summary
- Use per-module `project.description` for POM descriptions instead of a generic string
- Fix deprecated `git://` SCM URL to `https://` in POM metadata
- Fix signing block indentation in `configurePublishing()`
- Bump version to 2.7.1 and update docs (README, CLAUDE.md, llms.txt)

## Test plan
- [ ] Verify `make build` passes
- [ ] Verify POM descriptions are correct via `./gradlew :core-utils:generatePomFileForMavenPublication` and inspect the generated POM

🤖 Generated with [Claude Code](https://claude.com/claude-code)