### PR TITLE
Consolidate Dokka docs in root project and clean up code (#92)

### DIFF
--- a/.github/workflows/kdocs.yml
+++ b/.github/workflows/kdocs.yml
@@ -1,0 +1,24 @@
+name: KDocs
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  kdocs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Generate KDocs
+        run: ./gradlew :dokkaGenerate

--- a/.github/workflows/kdocs.yml
+++ b/.github/workflows/kdocs.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   kdocs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ lint:
 versioncheck:
 	./gradlew dependencyUpdates --no-configuration-cache
 
+kdocs:
+	./gradlew :dokkaGenerate
+
 publish-local:
 	./gradlew publishToMavenLocal
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,9 +11,13 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlinter) apply true
     alias(libs.plugins.versions) apply false
-    alias(libs.plugins.dokka) apply false
+    alias(libs.plugins.dokka)
     alias(libs.plugins.maven.publish) apply false
     // id("org.jetbrains.kotlinx.kover") version "0.5.0"
+}
+
+dependencies {
+    subprojects.forEach { dokka(project(it.path)) }
 }
 
 val versionStr: String by extra
@@ -38,6 +42,14 @@ allprojects {
 // Disable publishing for the root project — only subprojects should be published
 tasks.withType<PublishToMavenRepository>().configureEach { enabled = false }
 tasks.withType<PublishToMavenLocal>().configureEach { enabled = false }
+
+dokka {
+    moduleName.set("common-utils")
+    pluginsConfiguration.html {
+        homepageLink.set("https://github.com/pambrose/common-utils")
+        footerMessage.set("common-utils")
+    }
+}
 
 subprojects {
     configureKotlin()

--- a/core-utils/src/main/kotlin/com/pambrose/common/delegate/AtomicDelegates.kt
+++ b/core-utils/src/main/kotlin/com/pambrose/common/delegate/AtomicDelegates.kt
@@ -32,7 +32,7 @@ object AtomicDelegates {
 //  fun <T : Any?> nullableReference(initValue: T? = null): ReadWriteProperty<Any?, T> =
 //    NullableAtomicReferenceDelegate(initValue)
 
-  fun <T : Any?> singleSetReference(
+  fun <T> singleSetReference(
     initValue: T? = null,
     compareValue: T? = null,
   ): ReadWriteProperty<Any?, T?> = SingleSetAtomicReferenceDelegate(initValue, compareValue)
@@ -78,7 +78,7 @@ private class NonNullableAtomicReferenceDelegate<T : Any>(
 //   ) = atomicVal.store(value)
 // }
 
-private class SingleSetAtomicReferenceDelegate<T : Any?>(
+private class SingleSetAtomicReferenceDelegate<T>(
   initValue: T?,
   private val compareValue: T?,
 ) : ReadWriteProperty<Any?, T?> {

--- a/core-utils/src/main/kotlin/com/pambrose/common/delegate/SingleAssignVar.kt
+++ b/core-utils/src/main/kotlin/com/pambrose/common/delegate/SingleAssignVar.kt
@@ -29,9 +29,9 @@ object SingleAssignVar {
    *
    * @throws IllegalStateException if the property is assigned more than once
    */
-  fun <T : Any?> singleAssign(): ReadWriteProperty<Any?, T?> = ThreadSafeSingleAssignVar()
+  fun <T> singleAssign(): ReadWriteProperty<Any?, T?> = ThreadSafeSingleAssignVar()
 
-  private class ThreadSafeSingleAssignVar<T : Any?> : ReadWriteProperty<Any?, T?> {
+  private class ThreadSafeSingleAssignVar<T> : ReadWriteProperty<Any?, T?> {
     private val atomicValue = AtomicReference<ValueHolder<T>?>()
 
     // Wrapper to distinguish between null value and unset value

--- a/core-utils/src/main/kotlin/com/pambrose/common/util/ArrayUtils.kt
+++ b/core-utils/src/main/kotlin/com/pambrose/common/util/ArrayUtils.kt
@@ -16,9 +16,6 @@
 
 package com.pambrose.common.util
 
-import com.pambrose.common.util.asBracketed
-import com.pambrose.common.util.toDoubleQuoted
-
 object ArrayUtils {
   @JvmStatic
   fun arrayPrint(vals: BooleanArray) = println(asString(vals))

--- a/core-utils/src/main/kotlin/com/pambrose/common/util/ContentSource.kt
+++ b/core-utils/src/main/kotlin/com/pambrose/common/util/ContentSource.kt
@@ -23,12 +23,12 @@ interface ContentRoot {
   val sourcePrefix: String
   val remote: Boolean
 
-  fun file(path: String): com.pambrose.common.util.ContentSource
+  fun file(path: String): ContentSource
 }
 
 class FileSystemSource(
   val pathPrefix: String,
-) : com.pambrose.common.util.ContentRoot {
+) : ContentRoot {
   override val sourcePrefix = pathPrefix
   override val remote = false
 
@@ -50,10 +50,10 @@ enum class OwnerType {
 abstract class AbstractRepo(
   val scheme: String,
   val domainName: String,
-  val ownerType: com.pambrose.common.util.OwnerType,
+  val ownerType: OwnerType,
   val ownerName: String,
   val repoName: String,
-) : com.pambrose.common.util.ContentRoot {
+) : ContentRoot {
   override val sourcePrefix: String get() = scheme + listOf(domainName, ownerName, repoName).join()
   override val remote = true
   abstract val rawSourcePrefix: String

--- a/core-utils/src/test/kotlin/com/pambrose/concurrent/AtomicTests.kt
+++ b/core-utils/src/test/kotlin/com/pambrose/concurrent/AtomicTests.kt
@@ -21,6 +21,7 @@ package com.pambrose.concurrent
 import com.pambrose.common.concurrent.Atomic
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 
 class AtomicTests : StringSpec() {
@@ -61,7 +62,7 @@ class AtomicTests : StringSpec() {
           }
         }
 
-      jobs.forEach { it.join() }
+      jobs.joinAll()
 
       atomic.value shouldBe iterations
     }

--- a/core-utils/src/test/kotlin/com/pambrose/util/ArrayUtilsTests.kt
+++ b/core-utils/src/test/kotlin/com/pambrose/util/ArrayUtilsTests.kt
@@ -73,7 +73,7 @@ class ArrayUtilsTests : StringSpec() {
     }
 
     "string array test" {
-      ArrayUtils.asString(arrayOf<String>()) shouldBe "[]"
+      ArrayUtils.asString(arrayOf()) shouldBe "[]"
       ArrayUtils.asString(arrayOf("hello")) shouldBe "[\"hello\"]"
       ArrayUtils.asString(arrayOf("a", "b", "c")) shouldBe "[\"a\", \"b\", \"c\"]"
     }

--- a/core-utils/src/test/kotlin/com/pambrose/util/AtomicDelegatesTests.kt
+++ b/core-utils/src/test/kotlin/com/pambrose/util/AtomicDelegatesTests.kt
@@ -82,7 +82,7 @@ class AtomicDelegatesTests : StringSpec() {
     }
 
     "single set reference test" {
-      var value: String? by AtomicDelegates.singleSetReference<String>()
+      var value: String? by AtomicDelegates.singleSetReference()
       value shouldBe null
 
       // First set should work

--- a/core-utils/src/test/kotlin/com/pambrose/util/BugFixVerificationTests.kt
+++ b/core-utils/src/test/kotlin/com/pambrose/util/BugFixVerificationTests.kt
@@ -38,6 +38,7 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 
 class BugFixVerificationTests : StringSpec() {
@@ -90,7 +91,7 @@ class BugFixVerificationTests : StringSpec() {
           atomic.setWithLock { it + 1 }
         }
       }
-      jobs.forEach { it.join() }
+      jobs.joinAll()
       atomic.value shouldBe 500
     }
 
@@ -99,7 +100,7 @@ class BugFixVerificationTests : StringSpec() {
     // After fix: throws IllegalStateException when value has already been set
 
     "single set delegate throws on second write" {
-      var value: String? by AtomicDelegates.singleSetReference<String>()
+      var value: String? by AtomicDelegates.singleSetReference()
       value shouldBe null
 
       value = "first"

--- a/core-utils/src/test/kotlin/com/pambrose/util/IOExtensionsTests.kt
+++ b/core-utils/src/test/kotlin/com/pambrose/util/IOExtensionsTests.kt
@@ -26,7 +26,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.io.Serializable
-import kotlin.collections.get
 
 class IOExtensionsTests : StringSpec() {
   init {

--- a/email-utils/src/main/kotlin/com/pambrose/common/webhook/Bounce.kt
+++ b/email-utils/src/main/kotlin/com/pambrose/common/webhook/Bounce.kt
@@ -14,7 +14,7 @@
  *   limitations under the License.
  */
 
-package com.canvascache.email.msgs
+package com.pambrose.common.webhook
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/email-utils/src/main/kotlin/com/pambrose/common/webhook/Click.kt
+++ b/email-utils/src/main/kotlin/com/pambrose/common/webhook/Click.kt
@@ -14,7 +14,7 @@
  *   limitations under the License.
  */
 
-package com.canvascache.email.msgs
+package com.pambrose.common.webhook
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/email-utils/src/main/kotlin/com/pambrose/common/webhook/Data.kt
+++ b/email-utils/src/main/kotlin/com/pambrose/common/webhook/Data.kt
@@ -14,7 +14,7 @@
  *   limitations under the License.
  */
 
-package com.canvascache.email.msgs
+package com.pambrose.common.webhook
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/email-utils/src/main/kotlin/com/pambrose/common/webhook/Header.kt
+++ b/email-utils/src/main/kotlin/com/pambrose/common/webhook/Header.kt
@@ -14,7 +14,7 @@
  *   limitations under the License.
  */
 
-package com.canvascache.email.msgs
+package com.pambrose.common.webhook
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/email-utils/src/main/kotlin/com/pambrose/common/webhook/ResendWebhookMsg.kt
+++ b/email-utils/src/main/kotlin/com/pambrose/common/webhook/ResendWebhookMsg.kt
@@ -14,7 +14,7 @@
  *   limitations under the License.
  */
 
-package com.canvascache.email.msgs
+package com.pambrose.common.webhook
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/email-utils/src/test/kotlin/com/pambrose/common/webhook/WebhookDataTests.kt
+++ b/email-utils/src/test/kotlin/com/pambrose/common/webhook/WebhookDataTests.kt
@@ -2,11 +2,6 @@
 
 package com.pambrose.common.webhook
 
-import com.canvascache.email.msgs.Bounce
-import com.canvascache.email.msgs.Click
-import com.canvascache.email.msgs.Data
-import com.canvascache.email.msgs.Header
-import com.canvascache.email.msgs.ResendWebhookMsg
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.Json

--- a/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/ConditionalValue.kt
+++ b/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/ConditionalValue.kt
@@ -17,6 +17,7 @@
 package com.pambrose.common.concurrent
 
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -51,7 +52,7 @@ open class ConditionalValue<T>(
     timeoutDuration: Duration = Duration.INFINITE,
     predicate: (T) -> Boolean,
   ): Boolean =
-    withTimeoutOrNull(timeoutDuration.inWholeMilliseconds) {
+    withTimeoutOrNull(timeoutDuration.inWholeMilliseconds.milliseconds) {
       flowValue.first { predicate(it) }
       true
     } ?: false

--- a/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/LameBooleanWaiter.kt
+++ b/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/LameBooleanWaiter.kt
@@ -17,6 +17,7 @@
 package com.pambrose.common.concurrent
 
 import kotlin.coroutines.resume
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -107,7 +108,7 @@ fun main() =
       println("Coroutine 1: Value has changed to true!")
     }
 
-    delay(1000) // Simulate some delay before changing the value
+    delay(1000.milliseconds) // Simulate some delay before changing the value
     println("Main: Changing value to true.")
     waiter.changeValue(true)
 
@@ -120,7 +121,7 @@ fun main() =
       println("Coroutine 2: Value has changed to false!")
     }
 
-    delay(1000) // Simulate some delay before changing the value
+    delay(1000.milliseconds) // Simulate some delay before changing the value
     println("Main: Changing value to false.")
     waiter.changeValue(false)
 
@@ -135,11 +136,11 @@ fun main() =
       println("Coroutine 3: Value has changed to false!")
     }
 
-    delay(500)
+    delay(500.milliseconds)
     println("Main: Changing value to true (no change).")
     waiter2.changeValue(true) // This should not trigger the waiting coroutine
 
-    delay(500)
+    delay(500.milliseconds)
     println("Main: Changing value to false.")
     waiter2.changeValue(false) // This should trigger the waiting coroutine
 

--- a/guava-utils/src/test/kotlin/com/pambrose/util/ConditionalTests.kt
+++ b/guava-utils/src/test/kotlin/com/pambrose/util/ConditionalTests.kt
@@ -21,6 +21,7 @@ import com.pambrose.common.concurrent.ConditionalValue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -56,7 +57,7 @@ class ConditionalTests : StringSpec() {
       bool1.set(true)
       bool2.set(true)
 
-      jobs.forEach { it.join() }
+      jobs.joinAll()
 
       results shouldBe listOf(3, 1, 2)
     }
@@ -80,7 +81,7 @@ class ConditionalTests : StringSpec() {
         expected += id
       }
 
-      jobs.forEach { it.join() }
+      jobs.joinAll()
 
       results shouldBe expected
     }
@@ -104,7 +105,7 @@ class ConditionalTests : StringSpec() {
         expected += id
       }
 
-      jobs.forEach { it.join() }
+      jobs.joinAll()
 
       results shouldBe expected
     }
@@ -130,7 +131,7 @@ class ConditionalTests : StringSpec() {
         expected += id
       }
 
-      jobs.forEach { it.join() }
+      jobs.joinAll()
 
       results shouldBe expected
     }

--- a/json-utils/src/test/kotlin/com/pambrose/json/JsonTests.kt
+++ b/json-utils/src/test/kotlin/com/pambrose/json/JsonTests.kt
@@ -77,8 +77,6 @@ class BasicObject2(
   }
 }
 
-val l = List(5) { it -> it }
-
 class JsonTests : StringSpec() {
   init {
     val obj = BasicObject2(

--- a/ktor-client-utils/src/test/kotlin/com/pambrose/common/dsl/KtorDslTests.kt
+++ b/ktor-client-utils/src/test/kotlin/com/pambrose/common/dsl/KtorDslTests.kt
@@ -2,7 +2,6 @@
 
 package com.pambrose.common.dsl
 
-import com.pambrose.common.dsl.KtorDsl.blockingGet
 import com.pambrose.common.dsl.KtorDsl.httpClient
 import com.pambrose.common.dsl.KtorDsl.newHttpClient
 import com.pambrose.common.dsl.KtorDsl.withHttpClient

--- a/ktor-server-utils/src/main/kotlin/com/pambrose/common/servlet/KtorServletRequest.kt
+++ b/ktor-server-utils/src/main/kotlin/com/pambrose/common/servlet/KtorServletRequest.kt
@@ -81,7 +81,7 @@ class KtorServletRequest(
 
   override fun getProtocol(): String = request.httpVersion
 
-  override fun getContentType(): String? = request.contentType().toString()
+  override fun getContentType(): String = request.contentType().toString()
 
   override fun getRemoteAddr(): String = request.local.remoteAddress
 
@@ -99,17 +99,17 @@ class KtorServletRequest(
 
   override fun getIntHeader(name: String): Int = throw UnsupportedOperationException()
 
-  override fun getPathInfo(): String? = throw UnsupportedOperationException()
+  override fun getPathInfo(): String = throw UnsupportedOperationException()
 
-  override fun getPathTranslated(): String? = throw UnsupportedOperationException()
+  override fun getPathTranslated(): String = throw UnsupportedOperationException()
 
-  override fun getRemoteUser(): String? = throw UnsupportedOperationException()
+  override fun getRemoteUser(): String = throw UnsupportedOperationException()
 
   override fun isUserInRole(role: String): Boolean = throw UnsupportedOperationException()
 
-  override fun getUserPrincipal(): Principal? = throw UnsupportedOperationException()
+  override fun getUserPrincipal(): Principal = throw UnsupportedOperationException()
 
-  override fun getRequestedSessionId(): String? = throw UnsupportedOperationException()
+  override fun getRequestedSessionId(): String = throw UnsupportedOperationException()
 
   override fun getRequestURL(): StringBuffer = throw UnsupportedOperationException()
 
@@ -142,11 +142,11 @@ class KtorServletRequest(
 
   override fun getHttpServletMapping(): HttpServletMapping = throw UnsupportedOperationException()
 
-  override fun getAttribute(name: String): Any? = throw UnsupportedOperationException()
+  override fun getAttribute(name: String): Any = throw UnsupportedOperationException()
 
   override fun getAttributeNames(): Enumeration<String> = throw UnsupportedOperationException()
 
-  override fun getCharacterEncoding(): String? = throw UnsupportedOperationException()
+  override fun getCharacterEncoding(): String = throw UnsupportedOperationException()
 
   override fun setCharacterEncoding(env: String) = throw UnsupportedOperationException()
 

--- a/script-utils-common/src/test/kotlin/com/pambrose/common/script/ScriptUtilsTests.kt
+++ b/script-utils-common/src/test/kotlin/com/pambrose/common/script/ScriptUtilsTests.kt
@@ -12,7 +12,6 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import javax.script.Bindings
 import javax.script.ScriptContext
 import javax.script.ScriptEngine
 import javax.script.SimpleBindings

--- a/script-utils-java/src/main/kotlin/com/pambrose/common/script/JavaScript.kt
+++ b/script-utils-java/src/main/kotlin/com/pambrose/common/script/JavaScript.kt
@@ -18,7 +18,6 @@ package com.pambrose.common.script
 
 import ch.obermuhlner.scriptengine.java.Isolation
 import ch.obermuhlner.scriptengine.java.JavaScriptEngine
-import com.pambrose.common.script.AbstractScript
 import com.pambrose.common.script.ScriptUtils.engineBindings
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.Closeable

--- a/script-utils-kotlin/src/main/kotlin/com/pambrose/common/script/KotlinExprEvaluator.kt
+++ b/script-utils-kotlin/src/main/kotlin/com/pambrose/common/script/KotlinExprEvaluator.kt
@@ -16,6 +16,4 @@
 
 package com.pambrose.common.script
 
-import com.pambrose.common.script.AbstractExprEvaluator
-
 class KotlinExprEvaluator : AbstractExprEvaluator("kts")

--- a/script-utils-python/src/main/kotlin/com/pambrose/common/script/PythonExprEvaluator.kt
+++ b/script-utils-python/src/main/kotlin/com/pambrose/common/script/PythonExprEvaluator.kt
@@ -16,6 +16,4 @@
 
 package com.pambrose.common.script
 
-import com.pambrose.common.script.AbstractExprEvaluator
-
 class PythonExprEvaluator : AbstractExprEvaluator("py")

--- a/script-utils-python/src/main/kotlin/com/pambrose/common/script/PythonScript.kt
+++ b/script-utils-python/src/main/kotlin/com/pambrose/common/script/PythonScript.kt
@@ -16,7 +16,6 @@
 
 package com.pambrose.common.script
 
-import com.pambrose.common.script.AbstractScript
 import java.io.Closeable
 import javax.script.ScriptException
 import kotlin.reflect.KType


### PR DESCRIPTION
## Summary
- Aggregate all submodule Dokka HTML output into a single root-level site with cross-module linking, configuring module name, homepage link, and footer
- Update `kdocs` Makefile target to use the root `:dokkaGenerate` task
- Fix email-utils package declarations from `com.canvascache.email.msgs` to `com.pambrose.common.webhook`
- Remove redundant imports, simplify `<T : Any?>` type parameters to `<T>`, use `joinAll()` instead of `forEach { it.join() }`, and use Duration-typed `delay`/`withTimeoutOrNull` overloads
- Tighten nullable return types to non-null in `KtorServletRequest` where methods always throw

## Test plan
- [ ] Verify `make kdocs` generates consolidated docs at `build/dokka/html/index.html`
- [ ] Verify `./gradlew build` passes all tests across modules
- [ ] Verify email-utils tests pass with corrected package declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)