### PR TITLE
Fix missing POM description by deferring evaluation (#93)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,7 +123,7 @@ fun Project.configurePublishing() {
 
         pom {
             name.set(project.name)
-            description.set(project.description)
+            description.set(provider { project.description })
             url.set("https://github.com/pambrose/common-utils")
             licenses {
                 license {


### PR DESCRIPTION
## Summary
- Wrap `project.description` in `provider { }` so POM description is resolved lazily after subproject build scripts have executed
- Fixes Maven Central validation failure where all 19 subproject descriptions were missing

## Test plan
- [ ] Verify `./gradlew :core-utils:generatePomFileForMavenPublication` produces a POM with a `<description>` element
- [ ] Verify `./gradlew publishAndReleaseToMavenCentral` passes validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)