### PR TITLE
Add Kotlinx Kover coverage and Codecov CI upload (#102)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,14 @@ jobs:
 
       - name: Lint
         run: ./gradlew lintKotlinMain lintKotlinTest
+
+      - name: Generate Kover XML coverage report
+        run: ./gradlew koverXmlReport
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: build/reports/kover/report.xml
+          fail_ci_if_error: false
+          verbose: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ cases. Published on Maven Central.
 
 - `make lint` - Run Kotlinter linting
 - `./gradlew formatKotlinMain formatKotlinTest` - Auto-format code
+- `make coverage` - Generate aggregated Kover HTML coverage report (output under `build/reports/kover/html/`)
+- `make coverage-xml` - Generate aggregated Kover XML coverage report (e.g. for CI / Codacy)
 
 ### Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION := $(shell grep -E '^[[:space:]]*version[[:space:]]*=' build.gradle.kts | head -1 | sed 's/.*"\(.*\)"/\1/')
 
-.PHONY: default clean stop compile build lint refresh tests tree depends versioncheck kdocs \
+.PHONY: default clean stop compile build lint refresh tests tree depends versioncheck kdocs coverage coverage-xml \
 	check-gpg-env publish-local publish-local-snapshot publish-snapshot publish-maven-central upgrade-wrapper
 
 default: versioncheck
@@ -36,6 +36,12 @@ versioncheck:
 
 kdocs:
 	./gradlew :dokkaGenerate
+
+coverage:
+	./gradlew koverHtmlReport
+
+coverage-xml:
+	./gradlew koverXmlReport
 
 publish-local:
 	./gradlew publishToMavenLocal

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Kotlin version](https://img.shields.io/badge/kotlin-2.3.21-red?logo=kotlin)](http://kotlinlang.org)
 [![ktlint](https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081)](https://pinterest.github.io/ktlint/)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/5bb4750894844031a55375227acfff6f)](https://app.codacy.com/gh/pambrose/common-utils/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![codecov](https://codecov.io/gh/pambrose/common-utils/branch/master/graph/badge.svg)](https://codecov.io/gh/pambrose/common-utils)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 A collection of utility libraries for Kotlin and Java development.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.pambrose.kotlinter) apply false
     alias(libs.plugins.pambrose.testing) apply false
     alias(libs.plugins.dokka)
+    alias(libs.plugins.kover)
     alias(libs.plugins.maven.publish) apply false
 }
 
@@ -41,6 +42,7 @@ val subprojectPluginIds = listOf(
     libs.plugins.pambrose.testing,
     libs.plugins.pambrose.stable.versions,
     libs.plugins.dokka,
+    libs.plugins.kover,
     libs.plugins.maven.publish,
 ).map { it.get().pluginId }
 
@@ -52,6 +54,7 @@ subprojects {
     configurePublishing()
 
     rootProject.dependencies.add("dokka", this)
+    rootProject.dependencies.add("kover", this)
 }
 
 fun Project.configureKotlin() {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 # Plugin versions
 dokka = "2.2.0"
+kover = "0.9.1"
 mavenPublish = "0.36.0"
 
 # Library versions
@@ -145,4 +146,5 @@ pambrose-stable-versions = { id = "com.pambrose.stable-versions", version.ref = 
 pambrose-kotlinter = { id = "com.pambrose.kotlinter", version.ref = "gradlePlugins" }
 pambrose-testing = { id = "com.pambrose.testing", version.ref = "gradlePlugins" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }


### PR DESCRIPTION
## Summary
- Apply `org.jetbrains.kotlinx.kover` (0.9.1) at root and to every subproject; aggregate per-subproject coverage onto the root project using the same `rootProject.dependencies.add(...)` pattern already used for Dokka — so a single root `koverHtmlReport` / `koverXmlReport` covers all 19 utils modules
- Add `make coverage` (HTML, output under `build/reports/kover/html/`) and `make coverage-xml` (CI / Codecov, output at `build/reports/kover/report.xml`) targets
- CI: generate Kover XML in the `Test` workflow and upload to Codecov via `codecov/codecov-action@v5` using `CODECOV_TOKEN`; `fail_ci_if_error: false` so a Codecov outage does not break the build
- Add `codecov.yml` with conservative auto / 1% thresholds for project + patch status checks and a default PR comment layout
- Add Codecov badge to `README.md` and document the new make targets in `CLAUDE.md`

## Test plan
- [ ] `make coverage` produces an aggregated HTML report covering every subproject under `build/reports/kover/html/`
- [ ] `make coverage-xml` produces `build/reports/kover/report.xml` containing every `com.pambrose.common.*` package
- [ ] CI `Test` job's `koverXmlReport` step succeeds and the Codecov upload posts coverage to https://codecov.io/gh/pambrose/common-utils
- [ ] Add `CODECOV_TOKEN` repo secret in GitHub before merging (uploads work tokenless on public repos but are rate-limited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)