### PR TITLE
Move version/group to gradle.properties, tighten codecov, minor bumps (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Common Utils are documented in this file.
 
+## [2.8.2] - 2026-05-02
+
+- Add Kotlinx Kover coverage with aggregated HTML/XML reports across all modules and Codecov upload from CI
+- Add `codecov.yml`; gate patch coverage at 70% and silence no-change PR comments
+- Improve repository line coverage from ~52% to ~62%
+- Upgrade Gradle wrapper to 9.5.0; add GPG environment validation in the publish targets; deduplicate Dokka configuration
+- Move `group` and `version` from `build.gradle.kts` to `gradle.properties`; preserve `-PoverrideVersion` for snapshot/publish targets; update `Makefile` to read `VERSION` from `gradle.properties`
+- Switch `overrideVersion` and `signingInMemoryKey` reads to `providers.gradleProperty(...)`
+- Hoist Kover excludes to a shared list reused by the root aggregator and per-project filter
+- Derive POM SCM and homepage URLs from a shared `scmHost` constant; wrap `pom.name` in a provider for consistency with `description`
+- Enable `org.gradle.parallel=true`; pass `--no-parallel` to `versioncheck` (manes plugin is not parallel-safe)
+- Replace deprecated `DefaultJedisClientConfig.ssl(Boolean)` with `sslOptions(SslOptions.defaults())` (Jedis 7.4.2+)
+- Fix functional bugs in Redis, Python script handling, Banner, SystemMetrics, and Zipkin
+- Add `CountDownLatch.await(Duration)` extension in `guava-utils`
+- Bump `kover` 0.9.1 → 0.9.8, `grpc` 1.80.0 → 1.81.0, `netty-tcnative` 2.0.76.Final → 2.0.77.Final
+- Bump project version to 2.8.2
+
 ## [2.8.1] - 2026-04-24
 
 - Bump Kotlin to 2.3.21

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ These opt-ins are enabled globally:
 ### Key Technologies
 
 - Kotlin 2.3.21 with JVM target 17
-- Gradle 9.4.1 with Kotlin DSL
+- Gradle 9.5.0 with Kotlin DSL
 - Kotest + MockK for testing
 - Kotlinter for linting
 
@@ -97,6 +97,6 @@ All modules use: `com.pambrose.common.*`
 
 ### Version Management
 
-- Project version: "2.8.2" (set in `allprojects` block of root build.gradle.kts)
-- Group: "com.pambrose.common-utils"
+- Project version: "2.8.2" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
+- Group: "com.pambrose.common-utils" (set in `gradle.properties`)
 - All library versions in `gradle/libs.versions.toml`

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ depends:
 	./gradlew dependencies
 
 versioncheck:
-	./gradlew dependencyUpdates --no-configuration-cache
+	./gradlew dependencyUpdates --no-configuration-cache --no-parallel
 
 kdocs:
 	./gradlew :dokkaGenerate

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell grep -E '^[[:space:]]*version[[:space:]]*=' build.gradle.kts | head -1 | sed 's/.*"\(.*\)"/\1/')
+VERSION := $(shell sed -n 's/^version=\(.*\)/\1/p' gradle.properties)
 
 .PHONY: default clean stop compile build lint refresh tests tree depends versioncheck kdocs coverage coverage-xml \
 	check-gpg-env publish-local publish-local-snapshot publish-snapshot publish-maven-central upgrade-wrapper

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ dependencies {
 ## Technology Stack
 
 - **Languages**: Kotlin 2.3.21, Java
-- **Build System**: Gradle 9.4.1 with Kotlin DSL
+- **Build System**: Gradle 9.5.0 with Kotlin DSL
 - **Testing**: Kotest, MockK
 - **Serialization**: Kotlinx.serialization
 - **Concurrency**: Kotlin Coroutines, Guava

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,37 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
+## v2.8.2 — 2026-05-02
+
+### Highlights
+
+- **Coverage with Kover + Codecov**: Added Kotlinx Kover with aggregated HTML and XML reports across all modules, a `codecov.yml`, and a CI upload to Codecov. Patch coverage is gated at 70% on PRs.
+- **Improved test coverage**: Lifted line coverage from ~52% to ~62% across the repository.
+- **Gradle wrapper 9.5.0 + GPG validation**: Bumped the wrapper to 9.5.0, added GPG environment validation in the publish targets, deduplicated Dokka configuration, and bumped project version to 2.8.2.
+
+### Build improvements
+
+- Moved `group` and `version` from `build.gradle.kts` to `gradle.properties`; preserved `-PoverrideVersion` for the Makefile snapshot/publish targets and updated the Makefile to read `VERSION` from `gradle.properties`.
+- Switched property reads (`overrideVersion`, `signingInMemoryKey`) to `providers.gradleProperty(...)` for modern Gradle idiom.
+- Hoisted Kover excludes to a single shared list reused by the root aggregator and the per-project filter.
+- Derived the POM SCM and homepage URLs from a shared `scmHost` constant; wrapped `pom.name` in a provider for consistency with `description`.
+- Enabled `org.gradle.parallel=true`; passed `--no-parallel` to `versioncheck` (the `manes` plugin is not parallel-safe).
+
+### Bug fixes
+
+- Replaced deprecated `DefaultJedisClientConfig.ssl(Boolean)` with `sslOptions(SslOptions.defaults())` (Jedis 7.4.2+).
+- Fixed functional bugs in Redis, Python script handling, Banner, SystemMetrics, and Zipkin.
+
+### Dependency bumps
+
+- `kover` 0.9.1 → 0.9.8
+- `grpc` 1.80.0 → 1.81.0
+- `netty-tcnative` 2.0.76.Final → 2.0.77.Final
+
+**Full Changelog**: https://github.com/pambrose/common-utils/compare/2.8.1...2.8.2
+
+---
+
 ## v2.8.1 — 2026-04-24
 
 ### Highlights

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,11 +17,13 @@ plugins {
     alias(libs.plugins.maven.publish) apply false
 }
 
+// version/group are set in gradle.properties; -PoverrideVersion overrides version
 allprojects {
-    findProperty("overrideVersion")?.toString()?.let { version = it }
+    providers.gradleProperty("overrideVersion").orNull?.let { version = it }
 }
 
-val projectHomepage = "https://github.com/pambrose/common-utils"
+val scmHost = "github.com/pambrose/common-utils"
+val projectHomepage = "https://$scmHost"
 val dokkaFooter = "common-utils"
 
 fun DokkaExtension.configureHtml() {
@@ -34,6 +36,22 @@ fun DokkaExtension.configureHtml() {
 dokka {
     moduleName.set("common-utils")
     configureHtml()
+}
+
+val koverExcludeClasses = listOf(
+    "com.pambrose.common.concurrent.ConditionalValueKt*",
+    "com.pambrose.common.concurrent.LameBooleanWaiterKt*",
+    "com.pambrose.common.concurrent.GenericValueWaiterKt*",
+)
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes(koverExcludeClasses)
+            }
+        }
+    }
 }
 
 val subprojectPluginIds = listOf(
@@ -56,20 +74,6 @@ subprojects {
 
     rootProject.dependencies.add("dokka", this)
     rootProject.dependencies.add("kover", this)
-}
-
-kover {
-    reports {
-        filters {
-            excludes {
-                classes(
-                    "com.pambrose.common.concurrent.ConditionalValueKt*",
-                    "com.pambrose.common.concurrent.LameBooleanWaiterKt*",
-                    "com.pambrose.common.concurrent.GenericValueWaiterKt*",
-                )
-            }
-        }
-    }
 }
 
 fun Project.configureKotlin() {
@@ -102,11 +106,7 @@ fun Project.configureKover() {
             filters {
                 excludes {
                     // Demo `main()`/`mainN()` functions colocated in production sources for manual playground use.
-                    classes(
-                        "com.pambrose.common.concurrent.ConditionalValueKt*",
-                        "com.pambrose.common.concurrent.LameBooleanWaiterKt*",
-                        "com.pambrose.common.concurrent.GenericValueWaiterKt*",
-                    )
+                    classes(koverExcludeClasses)
                 }
             }
         }
@@ -121,12 +121,12 @@ fun Project.configurePublishing() {
                 sourcesJar = SourcesJar.Sources(),
             ),
         )
-        coordinates(group.toString(), project.name, version.toString())
+        coordinates(project.group.toString(), project.name, project.version.toString())
 
         pom {
-            name.set(project.name)
+            name.set(provider { project.name })
             description.set(provider { project.description })
-            url.set("https://github.com/pambrose/common-utils")
+            url.set(projectHomepage)
             licenses {
                 license {
                     name.set("Apache License 2.0")
@@ -141,14 +141,14 @@ fun Project.configurePublishing() {
                 }
             }
             scm {
-                connection.set("scm:git:https://github.com/pambrose/common-utils.git")
-                developerConnection.set("scm:git:ssh://github.com/pambrose/common-utils.git")
-                url.set("https://github.com/pambrose/common-utils")
+                connection.set("scm:git:https://$scmHost.git")
+                developerConnection.set("scm:git:ssh://$scmHost.git")
+                url.set(projectHomepage)
             }
         }
 
         publishToMavenCentral(automaticRelease = true)
-        if (project.findProperty("signingInMemoryKey") != null) {
+        if (providers.gradleProperty("signingInMemoryKey").isPresent) {
             signAllPublications()
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,8 +18,7 @@ plugins {
 }
 
 allprojects {
-    version = findProperty("overrideVersion")?.toString() ?: "2.8.2"
-    group = "com.pambrose.common-utils"
+    findProperty("overrideVersion")?.toString()?.let { version = it }
 }
 
 val projectHomepage = "https://github.com/pambrose/common-utils"

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,10 +6,10 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: auto
+        target: 70%
         threshold: 1%
 
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
-  require_changes: false
+  require_changes: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,5 @@ kotlin.code.style=official
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.daemon=true
+org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m -Xss10m -Dkotlin.daemon.jvm.options=-Xss10m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,8 @@
+group=com.pambrose.common-utils
+version=2.8.2
+
 kotlin.code.style=official
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m -Xss10m -Dkotlin.daemon.jvm.options=-Xss10m
-# This is a workaround for manes version gradle issue when using coveralls
-# https://github.com/gradle/gradle/issues/26672
-#systemProp.javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
-#systemProp.javax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
-#systemProp.javax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Plugin versions
 dokka = "2.2.0"
-kover = "0.9.1"
+kover = "0.9.8"
 mavenPublish = "0.36.0"
 
 # Library versions
@@ -12,7 +12,7 @@ datetime = "0.7.1-0.6.x-compat"
 dropwizard = "4.2.38"
 exposed = "1.2.0"
 gradlePlugins = "1.0.14"
-grpc = "1.80.0"
+grpc = "1.81.0"
 guava = "33.0.0-jre"
 jakartaServlet = "6.1.0"
 javaScripting = "2.0.0"
@@ -22,7 +22,7 @@ kotlinxHtml = "0.12.0"
 ktor = "3.4.3"
 logging = "8.0.01"
 mockk = "1.14.9"
-nettyTcNative = "2.0.76.Final"
+nettyTcNative = "2.0.77.Final"
 prometheus = "0.16.0"
 python = "2.7.4"
 redis = "7.5.0"

--- a/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/ConcurrentExtensions.kt
+++ b/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/ConcurrentExtensions.kt
@@ -20,7 +20,9 @@ package com.pambrose.common.concurrent
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit.MILLISECONDS
 import kotlin.concurrent.thread
+import kotlin.time.Duration
 
 /** Whether this [CountDownLatch] has reached zero. */
 val CountDownLatch.isFinished: Boolean get() = count == 0L
@@ -38,6 +40,15 @@ fun CountDownLatch.countDown(block: () -> Unit) {
     countDown()
   }
 }
+
+/**
+ * Waits for the `CountDownLatch` to reach zero, or for the specified duration to elapse.
+ *
+ * @param duration the maximum time to wait, specified as a [Duration].
+ * @return `true` if the `CountDownLatch` reached zero within the specified duration,
+ *         `false` if the waiting time elapsed before the count reached zero.
+ */
+fun CountDownLatch.await(duration: Duration): Boolean = await(duration.inWholeMilliseconds, MILLISECONDS)
 
 /**
  * Acquires a permit from this [Semaphore], executes [block], and releases the permit in a `finally` block.

--- a/guava-utils/src/test/kotlin/com/pambrose/common/concurrent/ConcurrentExtensionsTests.kt
+++ b/guava-utils/src/test/kotlin/com/pambrose/common/concurrent/ConcurrentExtensionsTests.kt
@@ -23,6 +23,8 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Semaphore
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class ConcurrentExtensionsTests : StringSpec() {
   init {
@@ -85,6 +87,20 @@ class ConcurrentExtensionsTests : StringSpec() {
       }
 
       semaphore.availablePermits() shouldBe 1
+    }
+
+    "count down latch await with duration returns true when reached" {
+      val latch = CountDownLatch(1)
+      latch.countDown()
+
+      latch.await(1.seconds) shouldBe true
+    }
+
+    "count down latch await with duration returns false on timeout" {
+      val latch = CountDownLatch(1)
+
+      latch.await(50.milliseconds) shouldBe false
+      latch.isFinished shouldBe false
     }
 
     "thread with latch" {

--- a/redis-utils/src/main/kotlin/com/pambrose/common/redis/RedisUtils.kt
+++ b/redis-utils/src/main/kotlin/com/pambrose/common/redis/RedisUtils.kt
@@ -25,6 +25,7 @@ import redis.clients.jedis.DefaultJedisClientConfig
 import redis.clients.jedis.HostAndPort
 import redis.clients.jedis.Protocol.DEFAULT_TIMEOUT
 import redis.clients.jedis.RedisClient
+import redis.clients.jedis.SslOptions
 import redis.clients.jedis.UnifiedJedis
 import redis.clients.jedis.exceptions.JedisConnectionException
 import redis.clients.jedis.params.ScanParams
@@ -101,7 +102,7 @@ object RedisUtils {
       DefaultJedisClientConfig.builder()
         .connectionTimeoutMillis(DEFAULT_TIMEOUT)
         .socketTimeoutMillis(DEFAULT_TIMEOUT)
-        .ssl(isSsl)
+        .apply { if (isSsl) sslOptions(SslOptions.defaults()) }
 
     if (info.password.isNotBlank()) {
       if (info.includeUserInAuth)


### PR DESCRIPTION
## Summary
- Move `group`/`version` from `build.gradle.kts` to `gradle.properties`; preserve `-PoverrideVersion` override path used by Makefile snapshot/publish targets.
- Update `Makefile` to read `VERSION` from `gradle.properties` instead of grepping `build.gradle.kts`.
- Tighten `codecov.yml`: patch coverage `target: 70%` (was `auto`) and `comment.require_changes: true` to reduce no-op PR comments.
- Bump deps: `kover` 0.9.1 → 0.9.8, `grpc` 1.80.0 → 1.81.0, `netty-tcnative` 2.0.76.Final → 2.0.77.Final.
- Add `CountDownLatch.await(Duration)` extension in `guava-utils`.

## Test plan
- [ ] `./gradlew :core-utils:properties -q` reports `group=com.pambrose.common-utils`, `version=2.8.2`.
- [ ] `./gradlew :core-utils:properties -q -PoverrideVersion=2.8.2-SNAPSHOT` reports `version=2.8.2-SNAPSHOT`.
- [ ] `make -n publish-local-snapshot` resolves to `-PoverrideVersion=2.8.2-SNAPSHOT publishToMavenLocal`.
- [ ] `make build` succeeds.
- [ ] `make tests` succeeds.
- [ ] Codecov status checks behave as expected on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)