### PR TITLE
Add detekt target, fail-fast version checks, and coverage docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Common Utils are documented in this file.
 
+## [2.8.3] - 2026-05-08
+
+- Wire **Detekt 1.23.8** into every subproject via `configureDetekt()` in the root `build.gradle.kts`, with HTML/XML reports per module and auto-detection of optional `config/detekt/detekt.yml` and `config/detekt/baseline.xml`
+- Add a `config/detekt/detekt.yml` tailored for a multi-module utility library (disables threshold-style rules, excludes test code from `EmptyFunctionBlock` / `VariableNaming`); resolve the remaining real findings in `core-utils`, `script-utils-kotlin`, and `json-utils` tests
+- Add `grpc-utils` tests: `TlsUtilsTests` (11 cases) and `ServerExtensionsTests` (5 cases); add `mockk` to `grpc-utils` test dependencies
+- Centralize the Gradle wrapper version (`9.5.0`) and JVM target (`17`) under a `# Toolchain` section in `gradle/libs.versions.toml`; consume them from `build.gradle.kts` and the `Makefile`'s `upgrade-wrapper` target
+- Consolidate duplicated string literals in `build.gradle.kts` (`common-utils`, `"17"`, `config/detekt`) into named vals
+- Add `make detekt` and `make detekt-baseline` targets; `make lint` now also runs Detekt
+- Add `make help` for a self-documenting target list, parsed from `## description` comments
+- Add Kover coverage subcommands: `coverage-html`, `coverage-log`, `coverage-verify`, `coverage-open`, `coverage-packages`, `coverage-clean`; `make coverage` now generates both HTML and XML
+- Move the `coverage-packages` inline Python to `scripts/coverage-packages.py` with a friendlier missing-report error
+- Add fail-fast guards in the `Makefile` when `VERSION` or `GRADLE_VERSION` cannot be parsed, instead of silently passing empty strings to publish/wrapper commands
+- Pass `ORG_GRADLE_PROJECT_signingInMemoryKeyId` in `GPG_ENV` so the in-memory signing plugin has all three required properties
+- Drop the unused `compile` alias from the `Makefile`
+- Bump project version to 2.8.3
+
 ## [2.8.2] - 2026-05-02
 
 - Add Kotlinx Kover coverage with aggregated HTML/XML reports across all modules and Codecov upload from CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,14 @@ cases. Published on Maven Central.
 - `./gradlew formatKotlinMain formatKotlinTest` - Auto-format code
 - `make detekt` - Run Detekt static analysis across all modules (HTML/XML reports under `build/reports/detekt/`)
 - `make detekt-baseline` - Generate/update `config/detekt/baseline.xml` to suppress current findings
-- `make coverage` - Generate aggregated Kover HTML coverage report (output under `build/reports/kover/html/`)
+- `make coverage` - Generate both aggregated Kover HTML and XML coverage reports
+- `make coverage-html` - Generate aggregated Kover HTML coverage report (output under `build/reports/kover/html/`)
 - `make coverage-xml` - Generate aggregated Kover XML coverage report (e.g. for CI / Codacy)
+- `make coverage-log` - Print Kover coverage summary to the build log
+- `make coverage-verify` - Run Kover coverage verification rules
+- `make coverage-open` - Generate the HTML report and open it in the default browser
+- `make coverage-packages` - Print a per-package coverage table derived from the XML report
+- `make coverage-clean` - Clean Kover outputs and previous test results
 
 ### Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,11 @@ cases. Published on Maven Central.
 
 ## Common Development Commands
 
+Run `make help` for a self-documenting list of every target.
+
 ### Building
 
-- `make build` (alias: `make compile`) - Build without tests
+- `make build` - Build without tests
 - `./gradlew build` - Full build with tests
 - `make clean` - Run `gradle clean`
 - `make stop` - Stop the Gradle daemon

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
-.PHONY: default clean stop compile build lint detekt detekt-baseline refresh tests tree depends versioncheck kdocs \
-	coverage coverage-xml check-gpg-env publish-local publish-local-snapshot publish-snapshot publish-maven-central \
-	upgrade-wrapper
+.PHONY: default clean stop build lint detekt detekt-baseline refresh tests tree depends versioncheck kdocs \
+	coverage coverage-html coverage-xml coverage-log coverage-verify coverage-open coverage-packages coverage-clean \
+	check-gpg-env publish-local publish-local-snapshot publish-snapshot publish-maven-central upgrade-wrapper
 
 VERSION := $(shell sed -n 's/^version=\(.*\)/\1/p' gradle.properties)
+
+ifeq ($(strip $(VERSION)),)
+$(error Could not determine project version from gradle.properties)
+endif
+
 GRADLE_VERSION := $(shell sed -n 's/^gradle = "\(.*\)"/\1/p' gradle/libs.versions.toml)
+
+ifeq ($(strip $(GRADLE_VERSION)),)
+$(error Could not determine gradle version from gradle/libs.versions.toml)
+endif
 
 default: versioncheck
 
@@ -13,13 +22,14 @@ clean:
 stop:
 	./gradlew --stop
 
-compile:
+build:
 	./gradlew build -xtest
 
-build: compile
+lint: detekt
+	./gradlew lintKotlinMain lintKotlinTest
 
-lint:
-	./gradlew lintKotlinMain lintKotlinTest detekt
+detekt:
+	./gradlew detekt
 
 detekt-baseline:
 	./gradlew detektBaseline
@@ -83,6 +93,7 @@ publish-local-snapshot:
 
 GPG_ENV = \
 	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
+	ORG_GRADLE_PROJECT_signingInMemoryKeyId="$$GPG_SIGNING_KEY_ID" \
 	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)
 
 check-gpg-env:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default clean stop build lint detekt detekt-baseline refresh tests tree depends versioncheck kdocs \
+.PHONY: default help clean stop build lint detekt detekt-baseline refresh tests tree depends versioncheck kdocs \
 	coverage coverage-html coverage-xml coverage-log coverage-verify coverage-open coverage-packages coverage-clean \
 	check-gpg-env publish-local publish-local-snapshot publish-snapshot publish-maven-central upgrade-wrapper
 
@@ -16,79 +16,74 @@ endif
 
 default: versioncheck
 
-clean:
+help: ## Show available make targets
+	@awk 'BEGIN { FS = ":.*## "; printf "Usage: make <target>\n\nTargets:\n" } \
+		/^[a-zA-Z0-9_-]+:.*## / { printf "  %-22s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+clean: ## Run gradle clean
 	./gradlew clean
 
-stop:
+stop: ## Stop the Gradle daemon
 	./gradlew --stop
 
-build:
+build: ## Build without running tests
 	./gradlew build -xtest
 
-lint: detekt
+lint: detekt ## Run Kotlinter and Detekt
 	./gradlew lintKotlinMain lintKotlinTest
 
-detekt:
+detekt: ## Run Detekt static analysis
 	./gradlew detekt
 
-detekt-baseline:
+detekt-baseline: ## Generate or update the Detekt baseline
 	./gradlew detektBaseline
 
-coverage: coverage-html coverage-xml
+coverage: coverage-html coverage-xml ## Generate Kover HTML and XML reports
 
-coverage-html:
+coverage-html: ## Generate Kover HTML coverage report
 	./gradlew koverHtmlReport
 
-coverage-xml:
+coverage-xml: ## Generate Kover XML coverage report
 	./gradlew koverXmlReport
 
-coverage-log:
+coverage-log: ## Print Kover coverage summary to the build log
 	./gradlew koverLog
 
-coverage-verify:
+coverage-verify: ## Run Kover coverage verification rules
 	./gradlew koverVerify
 
-coverage-open: coverage-html
+coverage-open: coverage-html ## Generate and open the HTML coverage report
 	open build/reports/kover/html/index.html
 
-coverage-packages: coverage-xml
-	@python3 -c "import xml.etree.ElementTree as ET; \
-r = ET.parse('build/reports/kover/report.xml').getroot(); \
-pkgs = []; \
-[pkgs.append((p.get('name'), int(c.get('covered')), int(c.get('missed')))) \
- for p in r.findall('package') for c in p.findall('counter') if c.get('type') == 'INSTRUCTION']; \
-pkgs.sort(key=lambda x: -x[2]); \
-print(f\"{'package':<55} {'cov%':>6} {'covered':>9} {'missed':>9} {'total':>9}\"); \
-[print(f'{n:<55} {(c/(c+m)*100 if c+m else 0):6.1f} {c:9d} {m:9d} {c+m:9d}') for n,c,m in pkgs]; \
-tc=sum(p[1] for p in pkgs); tm=sum(p[2] for p in pkgs); \
-print(f'\nOVERALL: {tc/(tc+tm)*100:.2f}% ({tc}/{tc+tm} instructions, {tm} missed)')"
+coverage-packages: coverage-xml ## Print per-package coverage table from the XML report
+	@python3 scripts/coverage-packages.py
 
-coverage-clean:
+coverage-clean: ## Clean Kover outputs and previous test results
 	./gradlew cleanAllTests
 	rm -rf build/reports/kover build/kover
 
-refresh:
+refresh: ## Refresh dependencies and re-run dependencyUpdates
 	./gradlew --refresh-dependencies dependencyUpdates --no-configuration-cache
 
-tests:
+tests: ## Run lint and tests (./gradlew --rerun-tasks check)
 	./gradlew --rerun-tasks check
 
-tree:
+tree: ## Show dependency tree (quiet)
 	./gradlew -q dependencies
 
-depends:
+depends: ## Show dependency tree (verbose)
 	./gradlew dependencies
 
-versioncheck:
+versioncheck: ## Check for dependency updates (default target)
 	./gradlew dependencyUpdates --no-configuration-cache --no-parallel
 
-kdocs:
+kdocs: ## Generate Dokka HTML documentation
 	./gradlew :dokkaGenerate
 
-publish-local:
+publish-local: ## Install to local Maven repo
 	./gradlew publishToMavenLocal
 
-publish-local-snapshot:
+publish-local-snapshot: ## Install a -SNAPSHOT build to local Maven repo
 	./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenLocal
 
 GPG_ENV = \
@@ -96,7 +91,7 @@ GPG_ENV = \
 	ORG_GRADLE_PROJECT_signingInMemoryKeyId="$$GPG_SIGNING_KEY_ID" \
 	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)
 
-check-gpg-env:
+check-gpg-env: ## Verify GPG signing environment is configured
 	@if [ -z "$$GPG_SIGNING_KEY_ID" ]; then \
 		echo "Error: GPG_SIGNING_KEY_ID is not set" >&2; exit 1; \
 	fi
@@ -107,11 +102,11 @@ check-gpg-env:
 		echo "Error: keychain entry 'gradle-signing-password' (account 'gpg-signing') not found" >&2; exit 1; \
 	fi
 
-publish-snapshot: check-gpg-env
+publish-snapshot: check-gpg-env ## Publish a -SNAPSHOT to Maven Central
 	$(GPG_ENV) ./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenCentral
 
-publish-maven-central: check-gpg-env
+publish-maven-central: check-gpg-env ## Publish and release to Maven Central
 	$(GPG_ENV) ./gradlew publishAndReleaseToMavenCentral
 
-upgrade-wrapper:
+upgrade-wrapper: ## Re-run the Gradle wrapper task at the pinned version
 	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin

--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ dependencies {
 ### Building the Project
 
 ```bash
+# Show every available make target with descriptions
+make help
+
 # Build all modules
 ./gradlew build
 
@@ -248,16 +251,23 @@ make build
 # Run tests for a specific module
 ./gradlew :core-utils:test
 
-# Lint check
+# Lint check (Kotlinter + Detekt)
 make lint
+
+# Detekt static analysis only
+make detekt
+
+# Aggregated Kover coverage reports (HTML + XML)
+make coverage
 ```
 
 ### Code Quality
 
 This project maintains high code quality standards:
 
-- **Linting**: Kotlinter (ktlint)
+- **Linting**: Kotlinter (ktlint) and Detekt (config in `config/detekt/`)
 - **Testing**: Comprehensive test coverage with Kotest
+- **Coverage**: Kotlinx Kover with aggregated HTML/XML reports and Codecov upload from CI
 - **Security**: Regular dependency updates and security reviews
 - **Documentation**: Comprehensive module documentation
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,31 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
+## v2.8.3 — 2026-05-08
+
+### Highlights
+
+- **Detekt static analysis**: Wired Detekt 1.23.8 into every subproject with HTML/XML reports per module, a tailored `config/detekt/detekt.yml`, and an optional shared `config/detekt/baseline.xml`. `make detekt` is now a first-class target and `make lint` includes it.
+- **Centralized toolchain**: Moved the Gradle wrapper version (9.5.0) and JVM target (17) into `gradle/libs.versions.toml` under a new `# Toolchain` section, consumed from both `build.gradle.kts` and the `Makefile`.
+- **Self-documenting Makefile**: New `make help` target prints every available target with its description, parsed from `## description` comments.
+
+### Build improvements
+
+- Consolidated duplicated string literals in `build.gradle.kts` (`common-utils`, `"17"`, `config/detekt`) into named vals.
+- Added Kover coverage subcommands: `coverage-html`, `coverage-log`, `coverage-verify`, `coverage-open`, `coverage-packages`, `coverage-clean`. `make coverage` now generates both HTML and XML.
+- Moved `coverage-packages` inline Python to `scripts/coverage-packages.py` with a friendlier missing-report error.
+- Added fail-fast guards so the `Makefile` errors clearly when `VERSION` or `GRADLE_VERSION` cannot be parsed.
+- Passed `ORG_GRADLE_PROJECT_signingInMemoryKeyId` in `GPG_ENV` so the in-memory signing plugin has all three required properties.
+- Dropped the unused `compile` Makefile alias.
+
+### Tests
+
+- Added `grpc-utils` tests: `TlsUtilsTests` (11 cases) and `ServerExtensionsTests` (5 cases) covering trust/cert/key validation, `TlsContext.desc()` branches, `PLAINTEXT_CONTEXT`, graceful shutdown ordering, and the `require(timeout > 0)` precondition. Added `mockk` to `grpc-utils` test dependencies.
+
+**Full Changelog**: https://github.com/pambrose/common-utils/compare/2.8.2...2.8.3
+
+---
+
 ## v2.8.2 — 2026-05-02
 
 ### Highlights

--- a/scripts/coverage-packages.py
+++ b/scripts/coverage-packages.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Print a per-package Kover coverage table from build/reports/kover/report.xml."""
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+REPORT = Path("build/reports/kover/report.xml")
+
+
+def main() -> int:
+    if not REPORT.exists():
+        print(f"error: {REPORT} not found — run 'make coverage-xml' first", file=sys.stderr)
+        return 1
+
+    root = ET.parse(REPORT).getroot()
+    pkgs = [
+        (p.get("name"), int(c.get("covered")), int(c.get("missed")))
+        for p in root.findall("package")
+        for c in p.findall("counter")
+        if c.get("type") == "INSTRUCTION"
+    ]
+    pkgs.sort(key=lambda x: -x[2])
+
+    print(f"{'package':<55} {'cov%':>6} {'covered':>9} {'missed':>9} {'total':>9}")
+    for name, covered, missed in pkgs:
+        total = covered + missed
+        pct = (covered / total * 100) if total else 0
+        print(f"{name:<55} {pct:6.1f} {covered:9d} {missed:9d} {total:9d}")
+
+    total_covered = sum(p[1] for p in pkgs)
+    total_missed = sum(p[2] for p in pkgs)
+    grand_total = total_covered + total_missed
+    overall_pct = (total_covered / grand_total * 100) if grand_total else 0
+    print(f"\nOVERALL: {overall_pct:.2f}% ({total_covered}/{grand_total} instructions, {total_missed} missed)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds a standalone `make detekt` target (was documented in CLAUDE.md but missing from the Makefile) and reorders `lint` to depend on it
- Adds fail-fast guards so the Makefile errors out clearly when `VERSION` or `GRADLE_VERSION` cannot be parsed, instead of silently passing empty strings to publish/wrapper commands
- Completes `.PHONY` with the new coverage subtargets (`coverage-html`, `coverage-log`, `coverage-verify`, `coverage-open`, `coverage-packages`, `coverage-clean`) and drops the now-unused `compile` alias
- Passes `ORG_GRADLE_PROJECT_signingInMemoryKeyId` in `GPG_ENV` so the in-memory signing plugin has all three required properties
- Documents the new coverage subtargets and the updated `make coverage` (HTML + XML) behavior in CLAUDE.md

## Test plan
- [ ] `make detekt` runs `./gradlew detekt`
- [ ] `make coverage` produces both HTML and XML reports
- [ ] `make publish-snapshot` still picks up the version and signing properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)