### PR TITLE
Defer Makefile version checks and consolidate lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,10 @@
 .PHONY: default help clean stop build lint detekt detekt-baseline refresh tests tree depends versioncheck kdocs \
 	coverage coverage-html coverage-xml coverage-log coverage-verify coverage-open coverage-packages coverage-clean \
-	check-gpg-env publish-local publish-local-snapshot publish-snapshot publish-maven-central upgrade-wrapper
+	publish-local publish-local-snapshot publish-snapshot publish-maven-central upgrade-wrapper \
+	_check-gpg-env _require-version _require-gradle-version
 
 VERSION := $(shell sed -n 's/^version=\(.*\)/\1/p' gradle.properties)
-
-ifeq ($(strip $(VERSION)),)
-$(error Could not determine project version from gradle.properties)
-endif
-
 GRADLE_VERSION := $(shell sed -n 's/^gradle = "\(.*\)"/\1/p' gradle/libs.versions.toml)
-
-ifeq ($(strip $(GRADLE_VERSION)),)
-$(error Could not determine gradle version from gradle/libs.versions.toml)
-endif
 
 GPG_ENV = \
 	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
@@ -34,8 +26,8 @@ stop: ## Stop the Gradle daemon
 build: ## Build without running tests
 	./gradlew build -xtest
 
-lint: detekt ## Run Kotlinter and Detekt
-	./gradlew lintKotlinMain lintKotlinTest
+lint: ## Run Kotlinter and Detekt
+	./gradlew lintKotlinMain lintKotlinTest detekt
 
 detekt: ## Run Detekt static analysis
 	./gradlew detekt
@@ -88,25 +80,31 @@ kdocs: ## Generate Dokka HTML documentation
 publish-local: ## Install to local Maven repo
 	./gradlew publishToMavenLocal
 
-publish-local-snapshot: ## Install a -SNAPSHOT build to local Maven repo
+publish-local-snapshot: _require-version ## Install a -SNAPSHOT build to local Maven repo
 	./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenLocal
 
-check-gpg-env: ## Verify GPG signing environment is configured
-	@if [ -z "$$GPG_SIGNING_KEY_ID" ]; then \
-		echo "Error: GPG_SIGNING_KEY_ID is not set" >&2; exit 1; \
-	fi
-	@if ! gpg --list-secret-keys "$$GPG_SIGNING_KEY_ID" >/dev/null 2>&1; then \
-		echo "Error: no GPG secret key found for GPG_SIGNING_KEY_ID=$$GPG_SIGNING_KEY_ID" >&2; exit 1; \
-	fi
-	@if ! security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w >/dev/null 2>&1; then \
-		echo "Error: keychain entry 'gradle-signing-password' (account 'gpg-signing') not found" >&2; exit 1; \
-	fi
-
-publish-snapshot: check-gpg-env ## Publish a -SNAPSHOT to Maven Central
+publish-snapshot: _require-version _check-gpg-env ## Publish a -SNAPSHOT to Maven Central
 	$(GPG_ENV) ./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenCentral
 
-publish-maven-central: check-gpg-env ## Publish and release to Maven Central
+publish-maven-central: _check-gpg-env ## Publish and release to Maven Central
 	$(GPG_ENV) ./gradlew publishAndReleaseToMavenCentral
 
-upgrade-wrapper: ## Re-run the Gradle wrapper task at the pinned version
+upgrade-wrapper: _require-gradle-version ## Re-run the Gradle wrapper task at the pinned version
 	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin
+
+_check-gpg-env:
+	@if [ -z "$$GPG_SIGNING_KEY_ID" ]; then \
+		echo "ERROR: GPG_SIGNING_KEY_ID is not set" >&2; exit 1; \
+	fi
+	@if ! gpg --list-secret-keys "$$GPG_SIGNING_KEY_ID" >/dev/null 2>&1; then \
+		echo "ERROR: no GPG secret key found for GPG_SIGNING_KEY_ID=$$GPG_SIGNING_KEY_ID" >&2; exit 1; \
+	fi
+	@if ! security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w >/dev/null 2>&1; then \
+		echo "ERROR: keychain entry 'gradle-signing-password' (account 'gpg-signing') not found" >&2; exit 1; \
+	fi
+
+_require-version:
+	@[ -n "$(VERSION)" ] || { echo "ERROR: Could not determine project version from gradle.properties" >&2; exit 1; }
+
+_require-gradle-version:
+	@[ -n "$(GRADLE_VERSION)" ] || { echo "ERROR: Could not determine gradle version from gradle/libs.versions.toml" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- Replace top-level \`\$(error ...)\` blocks with lazy \`_require-version\` / \`_require-gradle-version\` prerequisites so non-publish targets still work when properties files are malformed
- Rename \`check-gpg-env\` to \`_check-gpg-env\` and hide internal helpers from \`make help\` via the underscore prefix
- Fold \`detekt\` into the single \`lint\` Gradle invocation (one daemon attach instead of two)
- Standardize error prefixes on \`ERROR:\`

## Test plan
- [ ] \`make help\` lists only public targets
- [ ] \`make lint\` runs kotlinter + detekt in one Gradle call
- [ ] \`make publish-local-snapshot\` still resolves \`\$(VERSION)\` correctly
- [ ] \`make upgrade-wrapper\` still resolves \`\$(GRADLE_VERSION)\` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)