### PR TITLE
Bump Exposed to 1.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ ktor = "3.5.0"
 nettyTcNative = "2.0.77.Final"
 
 # Data
-exposed = "1.2.0"
+exposed = "1.3.0"
 redis = "7.5.0"
 
 # Scripting


### PR DESCRIPTION
## Summary
- Upgrade Exposed from 1.2.0 to 1.3.0

## Test plan
- [ ] `./gradlew :exposed-utils:test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)