### PR TITLE
Use lintKotlin shortcut in lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build: ## Build without running tests
 	./gradlew build -x test
 
 lint: ## Run Kotlinter and Detekt
-	./gradlew lintKotlinMain lintKotlinTest detekt
+	./gradlew lintKotlin detekt
 
 detekt: ## Run Detekt static analysis
 	./gradlew detekt


### PR DESCRIPTION
## Summary
- Replace explicit `lintKotlinMain lintKotlinTest` with the single `lintKotlin` aggregate task in the `lint` make target

## Test plan
- [ ] `make lint` runs both main and test source-set linting plus detekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)