### PR TITLE
Rename make targets and bump Kotlin/logging versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Run `make help` for a self-documenting list of every target.
 
 ### Code Quality
 
-- `make lint` - Run Kotlinter linting
+- `make lint` - Run Kotlinter and Detekt
 - `./gradlew formatKotlinMain formatKotlinTest` - Auto-format code
 - `make detekt` - Run Detekt static analysis across all modules (HTML/XML reports under `build/reports/detekt/`)
 - `make detekt-baseline` - Generate/update `config/detekt/baseline.xml` to suppress current findings
@@ -46,7 +46,7 @@ Run `make help` for a self-documenting list of every target.
 
 ### Dependencies
 
-- `make versioncheck` - Check for dependency updates (default `make` target)
+- `make versions` - Check for dependency updates
 - `make refresh` - Refresh dependencies and re-run `dependencyUpdates`
 - `make tree` - Show dependency tree (quiet)
 - `make depends` - Show dependency tree (verbose)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default help clean stop build lint detekt detekt-baseline refresh tests tree depends versioncheck kdocs \
+.PHONY: default help clean stop build lint detekt detekt-baseline refresh tests tree depends versions kdocs \
 	coverage coverage-html coverage-xml coverage-log coverage-verify coverage-open coverage-packages coverage-clean \
 	publish-local publish-local-snapshot publish-snapshot publish-maven-central upgrade-wrapper \
 	_check-gpg-env _require-version _require-gradle-version
@@ -71,7 +71,7 @@ tree: ## Show dependency tree (quiet)
 depends: ## Show dependency tree (verbose)
 	./gradlew dependencies
 
-versions: ## Check for dependency updates (default target)
+versions: ## Check for dependency updates
 	./gradlew dependencyUpdates --no-configuration-cache --no-parallel
 
 kdocs: ## Generate Dokka HTML documentation

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GPG_ENV = \
 	ORG_GRADLE_PROJECT_signingInMemoryKeyId="$$GPG_SIGNING_KEY_ID" \
 	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)
 
-default: versioncheck
+default: help
 
 help:  ## Show this help (list of targets)
 	@awk 'BEGIN {FS = ":.*?## "; printf "Usage: make <target>\n\nTargets:\n"} \
@@ -71,7 +71,7 @@ tree: ## Show dependency tree (quiet)
 depends: ## Show dependency tree (verbose)
 	./gradlew dependencies
 
-versioncheck: ## Check for dependency updates (default target)
+versions: ## Check for dependency updates (default target)
 	./gradlew dependencyUpdates --no-configuration-cache --no-parallel
 
 kdocs: ## Generate Dokka HTML documentation

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -202,7 +202,7 @@ Modules without test files: `ktor-client-utils`, `common-utils-bom`
 
 - **Up-to-date Dependencies**: Recent versions across the stack
 - **Gradle Version Catalog**: Centralized version management
-- **Dependency Updates**: Good tooling with `make versioncheck`
+- **Dependency Updates**: Good tooling with `make versions`
 - **Minimal Dependency Tree**: Each module includes only necessary dependencies
 
 ### 📋 Key Dependencies

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,14 +11,14 @@ kover = "0.9.8"
 mavenPublish = "0.36.0"
 
 # Kotlin & kotlinx
-kotlin = "2.3.21"
+kotlin = "2.4.0-RC"
 coroutines = "1.11.0"
 datetime = "0.7.1"
 kotlinxHtml = "0.12.0"
 serialization = "1.11.0"
 
 # Logging
-logging = "8.0.02"
+logging = "8.0.03"
 
 # Frameworks
 dropwizard = "4.2.38"


### PR DESCRIPTION
## Summary
- Change the default `make` target from `versioncheck` to `help`
- Rename the `versioncheck` target to `versions`
- Bump Kotlin to `2.4.0-RC`
- Bump logging to `8.0.03`

🤖 Generated with [Claude Code](https://claude.com/claude-code)