### PR TITLE
Add ByteArray.zip() overload mirroring String.zip()

### DIFF
--- a/guava-utils/src/main/kotlin/com/pambrose/common/util/ZipExtensions.kt
+++ b/guava-utils/src/main/kotlin/com/pambrose/common/util/ZipExtensions.kt
@@ -45,6 +45,26 @@ fun String.zip(): ByteArray =
     }
 
 /**
+ * Compresses this [ByteArray] using GZIP encoding.
+ *
+ * Equivalent to [String.zip] but operates on raw bytes, avoiding a redundant UTF-8 re-encoding when
+ * the caller already holds the content as a byte array. For the same content, `bytes.zip()` produces
+ * identical output to `string.zip()` when `bytes == string.toByteArray(StandardCharsets.UTF_8)`.
+ *
+ * @return a GZIP-compressed byte array, or [EMPTY_BYTE_ARRAY] if this array is empty.
+ */
+fun ByteArray.zip(): ByteArray =
+  if (isEmpty())
+    EMPTY_BYTE_ARRAY
+  else
+    ByteArrayOutputStream().use { baos ->
+      GZIPOutputStream(baos).use { gzos ->
+        gzos.write(this)
+      }
+      baos.toByteArray()
+    }
+
+/**
  * Checks whether this [ByteArray] has a GZIP magic number header.
  *
  * @return `true` if the byte array starts with the GZIP magic bytes, `false` otherwise.

--- a/guava-utils/src/test/kotlin/com/pambrose/util/ZipExtensionTests.kt
+++ b/guava-utils/src/test/kotlin/com/pambrose/util/ZipExtensionTests.kt
@@ -43,5 +43,26 @@ class ZipExtensionTests : StringSpec() {
       "".zip().unzip() shouldBe ""
       ByteArray(0).unzip() shouldBe ""
     }
+
+    "byte array zip round-trips through unzip" {
+      val s = "metric_value 42\nhttp_requests_total{code=\"200\"} 1027\n# EOF\n"
+      s.toByteArray(Charsets.UTF_8).zip().unzip() shouldBe s
+    }
+
+    "byte array zip round-trips multi-byte UTF-8 content" {
+      val s = "世界 metrics: éèê\n"
+      s.toByteArray(Charsets.UTF_8).zip().unzip() shouldBe s
+    }
+
+    "byte array zip produces identical output to string zip for the same content" {
+      val s = "kjwkjfhwekf cdsc ##444445 世界 wefwef\n".repeat(1000)
+      // ByteArray.zip() must be a drop-in for String.zip() when fed the string's UTF-8 bytes.
+      s.toByteArray(Charsets.UTF_8).zip().toList() shouldBe s.zip().toList()
+    }
+
+    "empty byte array zip test" {
+      ByteArray(0).zip() shouldBe ByteArray(0)
+      ByteArray(0).zip().unzip() shouldBe ""
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds a `ByteArray.zip()` GZIP-compression extension parallel to the existing `String.zip()`, so callers that already hold raw bytes don't have to round-trip through a `String` (and a redundant UTF-8 re-encode) just to compress.

- For matching content, `bytes.zip()` is **byte-identical** to `string.zip()` when `bytes == string.toByteArray(UTF_8)`.
- Round-trips cleanly through the existing `unzip()`, including multi-byte UTF-8.
- Returns `EMPTY_BYTE_ARRAY` for an empty input, matching `String.zip()`'s empty-handling.

## Tests
New `ZipExtensionTests` cases cover:
- byte-array round-trip through `unzip()`
- multi-byte UTF-8 content (`世界`, accented chars)
- byte-identical parity with `String.zip()` for the same content
- the empty-array case

`:guava-utils:check` + Kotlinter + Detekt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)