### PR TITLE
Remove the JVM shutdown hook on shutDown to fix a hook leak

### DIFF
--- a/service-utils/src/main/kotlin/com/pambrose/common/service/AbstractGenericService.kt
+++ b/service-utils/src/main/kotlin/com/pambrose/common/service/AbstractGenericService.kt
@@ -83,6 +83,12 @@ abstract class AbstractGenericService<T> protected constructor(
 
   private lateinit var serviceManager: ServiceManager
 
+  @Volatile
+  private var shutDownHook: Thread? = null
+
+  /** Visible for testing: the JVM shutdown hook currently registered for this service, or `null`. */
+  internal val registeredShutDownHook: Thread? get() = shutDownHook
+
   /** The JMX reporter for Dropwizard metrics. Initialized when metrics are enabled. */
   lateinit var jmxReporter: JmxReporter
 
@@ -169,7 +175,7 @@ abstract class AbstractGenericService<T> protected constructor(
 
     servletServiceOrNull?.startSync()
 
-    Runtime.getRuntime().addShutdownHook(shutDownHookAction(this))
+    shutDownHook = shutDownHookAction(this).also { Runtime.getRuntime().addShutdownHook(it) }
   }
 
   override fun shutDown() {
@@ -182,6 +188,14 @@ abstract class AbstractGenericService<T> protected constructor(
 
     if (isZipkinEnabled)
       zipkinReporterService.stopSync()
+
+    shutDownHook?.let { hook ->
+      // removeShutdownHook throws IllegalStateException if the JVM is already shutting down (e.g. when
+      // shutDown was triggered by the hook itself) and SecurityException under a SecurityManager; in both
+      // cases the hook simply remains registered until JVM exit, so swallow rather than fail the shutdown.
+      runCatching { Runtime.getRuntime().removeShutdownHook(hook) }
+      shutDownHook = null
+    }
 
     super.shutDown()
   }

--- a/service-utils/src/test/kotlin/com/pambrose/common/service/GenericServiceTests.kt
+++ b/service-utils/src/test/kotlin/com/pambrose/common/service/GenericServiceTests.kt
@@ -201,6 +201,18 @@ class GenericServiceTests : StringSpec() {
       service.isRunning shouldBe false
     }
 
+    "shutdown hook is registered on start and removed on stop" {
+      val service = TestJettyService(admin = disabledAdmin.copy(enabled = true, port = freePort()))
+      service.startSync()
+      val hook = service.registeredShutDownHook ?: error("expected a shutdown hook to be registered after start")
+
+      service.close()
+
+      service.registeredShutDownHook shouldBe null
+      // Removing it again reports false, proving shutDown already de-registered it (no leak).
+      Runtime.getRuntime().removeShutdownHook(hook) shouldBe false
+    }
+
     "addServices appends each provided service to the managed list" {
       val service = TestJettyService()
       val before = service.serviceCount


### PR DESCRIPTION
## Summary

`AbstractGenericService.startUp()` registered a new JVM shutdown hook on every start, but `shutDown()` never removed it. Every service instance therefore left a hook registered for the life of the JVM — an unbounded leak — and at JVM exit each leaked hook ran `stopAsync()`/`awaitTerminated()` against an already-`TERMINATED` service (wasted work). Thanks to the earlier `AbstractGenericService` extraction (#119), the fix only had to be applied in one place instead of two.

## Fix
- Store the hook in a field, register it in `startUp()`, and remove it in `shutDown()`.
- The removal is wrapped in `runCatching`: `removeShutdownHook()` throws `IllegalStateException` when the JVM is already shutting down (e.g. when `shutDown()` was itself triggered by the firing hook) and `SecurityException` under a `SecurityManager`. Both are swallowed so they can never fail the shutdown — in either case the hook just remains registered until JVM exit.
- The field is `@Volatile` so the test-only `registeredShutDownHook` accessor is well-defined when read off the service thread.

## Tests
New `GenericServiceTests` case starts a service, captures the registered hook, calls `close()`, then asserts the hook field is null and `Runtime.removeShutdownHook(hook)` returns `false` (proving `shutDown()` already de-registered it). It was confirmed to **fail on the pre-fix code** (`Expected null but actual was Thread[...]`) and pass after.

`:service-utils:check` + Kotlinter + Detekt all green.

## Review
The change was put through a 3-lens adversarial review (JVM-shutdown/deadlock, concurrency/visibility, correctness/edge-cases); all three returned "correct". The two low-severity nits it surfaced (broaden the swallow comment to mention `SecurityException`; mark the field `@Volatile`) are incorporated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)