### PR TITLE
Emit DO NOTHING when an UPSERT has no non-conflict columns to update

### DIFF
--- a/exposed-utils/src/main/kotlin/com/pambrose/common/exposed/UpsertStatement.kt
+++ b/exposed-utils/src/main/kotlin/com/pambrose/common/exposed/UpsertStatement.kt
@@ -60,8 +60,9 @@ inline fun <T : Table> T.upsert(
 /**
  * An [InsertStatement] that appends a PostgreSQL `ON CONFLICT ... DO UPDATE SET` clause.
  *
- * Generates SQL that inserts a row, and on conflict with the specified column or index constraint,
- * updates all non-conflict columns to the `EXCLUDED` values.
+ * Generates SQL that inserts a row and, on conflict with the specified column or index constraint,
+ * updates all non-conflict columns to their `EXCLUDED` values — or emits `DO NOTHING` when every
+ * inserted column belongs to the conflict key, since there is then nothing to update.
  *
  * @param Key the auto-generated key type
  * @param table the target table
@@ -93,9 +94,15 @@ class UpsertStatement<Key : Any>(
       // unique index, whereas ON CONSTRAINT requires an actual constraint name.
       append(" ON CONFLICT ")
       indexColumns.joinTo(this, separator = ", ", prefix = "(", postfix = ")") { transaction.identity(it) }
-      append(" DO UPDATE SET ")
-      values.keys
-        .filter { it !in indexColumns }
-        .joinTo(this) { "${transaction.identity(it)}=EXCLUDED.${transaction.identity(it)}" }
+
+      val updateColumns = values.keys.filter { it !in indexColumns }
+      if (updateColumns.isEmpty()) {
+        // Every inserted column is part of the conflict key, so there is nothing to update.
+        // `DO UPDATE SET` with no assignments is invalid SQL; `DO NOTHING` is the correct no-op.
+        append(" DO NOTHING")
+      } else {
+        append(" DO UPDATE SET ")
+        updateColumns.joinTo(this) { "${transaction.identity(it)}=EXCLUDED.${transaction.identity(it)}" }
+      }
     }
 }

--- a/exposed-utils/src/test/kotlin/com/pambrose/common/exposed/BugFixVerificationTests.kt
+++ b/exposed-utils/src/test/kotlin/com/pambrose/common/exposed/BugFixVerificationTests.kt
@@ -96,5 +96,22 @@ class BugFixVerificationTests : StringSpec() {
         sql shouldNotContain "ON CONSTRAINT"
       }
     }
+
+    // Bug: when every inserted column is part of the conflict key, the update-column list is empty,
+    // leaving a dangling `... DO UPDATE SET ` that PostgreSQL rejects. It must emit `DO NOTHING`.
+
+    "upsert with only conflict columns emits DO NOTHING instead of a dangling DO UPDATE SET" {
+      Database.connect("jdbc:h2:mem:upsert_nothing;MODE=PostgreSQL;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+      transaction {
+        val stmt = UpsertStatement<Number>(UpsertTestTable, conflictColumn = UpsertTestTable.email)
+        // The only inserted column is the conflict column, so there is nothing to update.
+        stmt[UpsertTestTable.email] = "a@b.com"
+
+        val sql = stmt.prepareSQL(this, prepared = false)
+        sql shouldContain "ON CONFLICT ("
+        sql shouldContain "DO NOTHING"
+        sql shouldNotContain "DO UPDATE SET"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

`UpsertStatement.prepareSQL()` unconditionally appended `DO UPDATE SET ` followed by the non-conflict columns. When **every** inserted column is part of the conflict key (e.g. a table whose only set columns are its unique key, or an insert that sets only key columns), that column list is empty, so the generated SQL ended with a dangling:

```
INSERT INTO upsert_test (email) VALUES ('a@b.com') ON CONFLICT (email) DO UPDATE SET 
```

PostgreSQL rejects this with a syntax error. The correct behavior in that case is `DO NOTHING`.

## Fix
Compute the update-column list first and branch:
- empty → `... ON CONFLICT (...) DO NOTHING`
- non-empty → the existing `... DO UPDATE SET col=EXCLUDED.col, ...`

Also updated the class KDoc to document the `DO NOTHING` case.

## Tests
New `BugFixVerificationTests` case sets only the conflict column and asserts the generated SQL contains `DO NOTHING` and **not** `DO UPDATE SET` (same `prepareSQL` + H2/PostgreSQL-mode pattern as the existing UPSERT tests). It was confirmed to **fail on the pre-fix code** — the assertion error showed the exact dangling SQL — and pass after.

`:exposed-utils:check` + Kotlinter + Detekt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)