### PR TITLE
Harden and centralize scripting exit guards (best-effort, not a sandbox)

### DIFF
--- a/script-utils-common/src/main/kotlin/com/pambrose/common/script/ScriptGuards.kt
+++ b/script-utils-common/src/main/kotlin/com/pambrose/common/script/ScriptGuards.kt
@@ -1,0 +1,66 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.pambrose.common.script
+
+import javax.script.ScriptException
+
+/**
+ * Best-effort guards that reject the most common, literal JVM-termination calls in evaluated JVM
+ * (Kotlin/Java) scripts: `System.exit(...)`, `kotlin.system.exitProcess(...)`, and
+ * `Runtime.getRuntime().exit(...)` / `.halt(...)`.
+ *
+ * **These guards are NOT a security sandbox.** They match only obvious, literal call forms by simple
+ * pattern matching and are trivially bypassed — for example by building the call from string fragments
+ * (`"ex" + "it"`), reflection, aliasing the runtime (`val r = Runtime.getRuntime(); r.halt(0)`), or any
+ * other indirection. They also match calls that appear inside string literals or comments. Their purpose
+ * is to catch *accidental* JVM termination during development, not to safely run untrusted code. To run
+ * untrusted scripts, isolate them in a separate process or JVM with a restrictive security policy.
+ */
+object ScriptGuards {
+  private val jvmExitPatterns =
+    listOf(
+      // System.exit(...), including fully-qualified java.lang.System.exit(...); not mySystem.exit(...)
+      Regex("""(?<!\w)System\s*\.\s*exit\s*\("""),
+      // bare exitProcess(...) (the imported Kotlin idiom); excludes obj.exitProcess(...) on a user object
+      Regex("""(?<![\w.])exitProcess\s*\("""),
+      // fully-qualified kotlin.system.exitProcess(...)
+      Regex("""(?<!\w)system\s*\.\s*exitProcess\s*\("""),
+      // Runtime.getRuntime().exit(...) / Runtime.getRuntime().halt(...)
+      Regex("""(?<!\w)Runtime\s*\.\s*getRuntime\s*\(\s*\)\s*\.\s*(?:exit|halt)\s*\("""),
+      // statically-imported getRuntime().exit/halt (no `Runtime.` prefix); excludes obj.getRuntime()
+      Regex("""(?<![\w.])getRuntime\s*\(\s*\)\s*\.\s*(?:exit|halt)\s*\("""),
+    )
+
+  /**
+   * Throws a [ScriptException] if any of [fragments] contains a recognized literal JVM-termination call.
+   *
+   * All fragments are scanned together, so a termination call split across, for example, an expression
+   * and a separate action/statement block is still detected.
+   *
+   * @param fragments the code fragments to scan (joined before matching)
+   * @throws ScriptException if a literal `System.exit`, `exitProcess`, or `Runtime.getRuntime().exit/halt`
+   *   call is found. This is a best-effort check, not a security boundary; see the class documentation.
+   */
+  fun checkNoJvmExit(vararg fragments: String) {
+    val code = fragments.joinToString("\n")
+    if (jvmExitPatterns.any { it.containsMatchIn(code) }) {
+      throw ScriptException(
+        "Illegal call to a JVM termination method (System.exit / exitProcess / Runtime.exit / Runtime.halt)",
+      )
+    }
+  }
+}

--- a/script-utils-common/src/test/kotlin/com/pambrose/common/script/ScriptGuardsTests.kt
+++ b/script-utils-common/src/test/kotlin/com/pambrose/common/script/ScriptGuardsTests.kt
@@ -1,0 +1,84 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.pambrose.common.script
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
+import io.kotest.core.spec.style.StringSpec
+import javax.script.ScriptException
+
+class ScriptGuardsTests : StringSpec() {
+  init {
+    // These tests only run the matcher on strings; they never evaluate scripts, so they cannot
+    // terminate the test JVM even when the input is a real termination call.
+
+    "rejects System.exit in its common forms" {
+      listOf(
+        "System.exit(0)",
+        "java.lang.System.exit(1)",
+        "System . exit ( 0 )",
+        "return System.exit(0);",
+      ).forEach { code ->
+        shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit(code) }
+      }
+    }
+
+    "rejects kotlin exitProcess" {
+      shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit("exitProcess(0)") }
+      shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit("kotlin.system.exitProcess(1)") }
+      shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit("exitProcess (2)") }
+    }
+
+    "rejects Runtime exit and halt" {
+      shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit("Runtime.getRuntime().exit(0)") }
+      shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit("Runtime.getRuntime().halt(0)") }
+      shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit("Runtime . getRuntime ( ) . halt ( 1 )") }
+      shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit("java.lang.Runtime.getRuntime().halt(0)") }
+    }
+
+    "rejects statically-imported bare getRuntime().exit/halt" {
+      // `import static java.lang.Runtime.getRuntime;` then `getRuntime().halt(0)` would kill the JVM.
+      shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit("getRuntime().exit(0)") }
+      shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit("getRuntime().halt(0)") }
+    }
+
+    "detects a termination call split across fragments" {
+      shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit("0", "System.exit(1);") }
+    }
+
+    "error message names the termination methods" {
+      val ex = shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit("System.exit(0)") }
+      ex.message shouldContain "exit"
+    }
+
+    "does not reject safe code or unrelated identifiers" {
+      listOf(
+        "val x = 1 + 2",
+        "mySystem.exit(0)",
+        "obj.exitProcess(args)",
+        "return value;",
+        "doExit()",
+        "println(\"done\")",
+      ).forEach { code ->
+        shouldNotThrow<ScriptException> { ScriptGuards.checkNoJvmExit(code) }
+      }
+    }
+  }
+}

--- a/script-utils-java/src/main/kotlin/com/pambrose/common/script/JavaScript.kt
+++ b/script-utils-java/src/main/kotlin/com/pambrose/common/script/JavaScript.kt
@@ -21,7 +21,6 @@ import ch.obermuhlner.scriptengine.java.JavaScriptEngine
 import com.pambrose.common.script.ScriptUtils.engineBindings
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.Closeable
-import javax.script.ScriptException
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
@@ -34,7 +33,9 @@ import kotlin.reflect.typeOf
  * Supports adding named variables with type parameters, import declarations, and
  * configurable isolation levels. Note that Java cannot have a null global context.
  *
- * Note: Java cannot have a null global context.
+ * Common literal JVM-termination calls (`System.exit`, `Runtime.getRuntime().exit/halt`) are rejected
+ * on a best-effort basis via [ScriptGuards]. This is a convenience against accidental termination,
+ * **not** a security sandbox (see [ScriptGuards]) — run untrusted scripts in an isolated process or JVM.
  *
  * @see AbstractScript
  * @see <a href="https://github.com/eobermuhlner/java-scriptengine">java-scriptengine</a>
@@ -121,6 +122,8 @@ class JavaScript :
     script: String,
     verbose: Boolean = false,
   ): Any {
+    ScriptGuards.checkNoJvmExit(script)
+
     if (!initialized) {
       valueMap.forEach { (name, value) -> engine.engineBindings[name] = value }
       initialized = true
@@ -140,8 +143,7 @@ class JavaScript :
     action: String = "",
     verbose: Boolean = false,
   ): Any {
-    if ("System.exit" in expr)
-      throw ScriptException("Illegal call to System.exit()")
+    ScriptGuards.checkNoJvmExit(expr, action)
 
     val code = """
 $importDecls

--- a/script-utils-java/src/test/kotlin/com/pambrose/common/script/JavaScriptTests.kt
+++ b/script-utils-java/src/test/kotlin/com/pambrose/common/script/JavaScriptTests.kt
@@ -221,6 +221,20 @@ class JavaScriptTests : StringSpec() {
       }
     }
 
+    "JVM termination calls are rejected before evaluation" {
+      // ScriptGuards rejects each of these before the engine compiles/runs, so the JVM is never killed.
+      JavaScript().use {
+        it.apply {
+          shouldThrow<ScriptException> { eval("System.exit(0)") }
+          // Previously the guard scanned only the expression, so a call in the action block slipped through.
+          shouldThrow<ScriptException> { eval("0", "System.exit(0);") }
+          shouldThrow<ScriptException> { eval("Runtime.getRuntime().halt(0)") }
+          // evalScript previously had no guard at all.
+          shouldThrow<ScriptException> { evalScript("System.exit(0);") }
+        }
+      }
+    }
+
     // Bug #5 (Java): JavaScriptPool's nullGlobalContext is ignored because Java binds variables
     // into the engine scope, never the global scope. The global context must stay non-null on both
     // the initial population and after recycling, even when the pool is created with true.

--- a/script-utils-kotlin/src/main/kotlin/com/pambrose/common/script/KotlinScript.kt
+++ b/script-utils-kotlin/src/main/kotlin/com/pambrose/common/script/KotlinScript.kt
@@ -18,7 +18,6 @@ package com.pambrose.common.script
 
 import com.pambrose.common.util.toDoubleQuoted
 import java.io.Closeable
-import javax.script.ScriptException
 
 // See: https://github.com/Kotlin/kotlin-script-examples/blob/master/jvm/jsr223/jsr223-simple/build.gradle.kts
 // See: https://kotlinexpertise.com/run-kotlin-scripts-from-kotlin-programs/
@@ -31,6 +30,11 @@ import javax.script.ScriptException
  * Manages variable bindings via the JSR 223 `Bindings` mechanism, generates Kotlin `val`
  * declarations that cast bound values to their appropriate types, and prepends import statements
  * to evaluated code.
+ *
+ * Common literal JVM-termination calls (`System.exit`, `exitProcess`, `Runtime.getRuntime().exit/halt`)
+ * are rejected on a best-effort basis via [ScriptGuards]; bare `System.exit` is additionally shadowed by
+ * the auto-imported [System] object. This is a convenience against accidental termination, **not** a
+ * security sandbox (see [ScriptGuards]) — run untrusted scripts in an isolated process or JVM.
  *
  * @param nullGlobalContext if `true`, sets the global scope bindings to `null` on initialization
  * @see AbstractScript
@@ -71,8 +75,7 @@ class KotlinScript(
 
   @Synchronized
   fun eval(code: String): Any? {
-    if ("java.lang.System.exit" in code)
-      throw ScriptException("Illegal call to System.exit()")
+    ScriptGuards.checkNoJvmExit(code)
 
     if (!initialized) {
       if (valueMap.isNotEmpty()) {

--- a/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/KotlinScriptTests.kt
+++ b/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/KotlinScriptTests.kt
@@ -256,10 +256,15 @@ class KotlinScriptTests : StringSpec() {
     }
 
     "illegal calls" {
+      // ScriptGuards rejects each of these before the engine runs, so the JVM is never terminated.
       KotlinScript().use {
         it.apply {
           shouldThrow<ScriptException> { eval("System.exit(1)") }
           shouldThrow<ScriptException> { eval("com.lang.System.exit(1)") }
+          shouldThrow<ScriptException> { eval("exitProcess(0)") }
+          shouldThrow<ScriptException> { eval("kotlin.system.exitProcess(0)") }
+          shouldThrow<ScriptException> { eval("Runtime.getRuntime().exit(0)") }
+          shouldThrow<ScriptException> { eval("Runtime.getRuntime().halt(0)") }
         }
       }
     }

--- a/script-utils-python/src/main/kotlin/com/pambrose/common/script/PythonScript.kt
+++ b/script-utils-python/src/main/kotlin/com/pambrose/common/script/PythonScript.kt
@@ -25,7 +25,13 @@ import org.python.jsr223.PyScriptEngine
  * A script engine wrapper for dynamically evaluating Python source code using the Jython engine.
  *
  * Variables are bound directly to the engine without type parameter support, since Python
- * is dynamically typed. Calls to `sys.exit()`, `exit()`, and `quit()` are blocked.
+ * is dynamically typed.
+ *
+ * Common literal calls to `sys.exit()`, `exit()`, and `quit()` are rejected on a best-effort basis.
+ * This is a convenience against accidental termination, **not** a security sandbox: it is trivially
+ * bypassed (e.g. `os._exit(0)`, `getattr(sys, 'ex' + 'it')(0)`, reflection, or any JVM access exposed
+ * by Jython), and it does not inspect string literals or comments. Run untrusted scripts in an isolated
+ * process or JVM. Method calls on user objects (for example `obj.exit()`) are intentionally allowed.
  *
  * @param nullGlobalContext if `true`, sets the global scope bindings to `null` on initialization
  * @see AbstractScript
@@ -56,6 +62,11 @@ class PythonScript(
     if (SYS_EXIT_PATTERN.containsMatchIn(code))
       throw ScriptException("Illegal call to sys.exit()")
 
+    // sys.exit()/exit()/quit() are all implemented as `raise SystemExit`, which is the same
+    // termination written directly; reject it too.
+    if (SYSTEM_EXIT_PATTERN.containsMatchIn(code))
+      throw ScriptException("Illegal 'raise SystemExit'")
+
     if (EXIT_PATTERN.containsMatchIn(code))
       throw ScriptException("Illegal call to exit()")
 
@@ -75,8 +86,11 @@ class PythonScript(
   }
 
   companion object {
+    // (?<![\w.]) excludes a preceding word char *or* '.', so a method call on a user object
+    // (e.g. obj.exit(), queue.quit()) is not mistaken for the bare Python builtin. Best-effort only.
     private val SYS_EXIT_PATTERN = Regex("""(?<!\w)sys\.exit\s*\(""")
-    private val EXIT_PATTERN = Regex("""(?<!\w)exit\s*\(""")
-    private val QUIT_PATTERN = Regex("""(?<!\w)quit\s*\(""")
+    private val SYSTEM_EXIT_PATTERN = Regex("""(?<!\w)raise\s+SystemExit\b""")
+    private val EXIT_PATTERN = Regex("""(?<![\w.])exit\s*\(""")
+    private val QUIT_PATTERN = Regex("""(?<![\w.])quit\s*\(""")
   }
 }

--- a/script-utils-python/src/test/kotlin/com/pambrose/common/script/PythonScriptTests.kt
+++ b/script-utils-python/src/test/kotlin/com/pambrose/common/script/PythonScriptTests.kt
@@ -20,6 +20,7 @@ import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import javax.script.ScriptException
 
 class IncClass(
@@ -27,6 +28,19 @@ class IncClass(
 ) {
   fun inc() {
     i++
+  }
+}
+
+class Exitable {
+  var calls = 0
+    private set
+
+  fun exit() {
+    calls++
+  }
+
+  fun quit() {
+    calls++
   }
 }
 
@@ -190,6 +204,20 @@ class PythonScriptTests : StringSpec() {
       }
     }
 
+    "raise SystemExit is rejected but referencing the type is allowed" {
+      PythonScript().use {
+        it.apply {
+          // `raise SystemExit` is exactly what sys.exit()/exit()/quit() do under the hood. The guard
+          // rejects it before evaluation; its message starts with "Illegal" (vs. a Jython runtime error).
+          shouldThrow<ScriptException> { eval("raise SystemExit") }.message shouldContain "Illegal"
+          shouldThrow<ScriptException> { eval("raise SystemExit(0)") }
+          shouldThrow<ScriptException> { eval("raise SystemExit('bye')") }
+          // Catching it (no `raise`) is legitimate and must not be flagged.
+          shouldNotThrow<ScriptException> { eval("try:\n  pass\nexcept SystemExit:\n  pass") }
+        }
+      }
+    }
+
     "exit guards do not match identifiers containing exit/quit substrings" {
       PythonScript().use {
         it.apply {
@@ -212,6 +240,21 @@ class PythonScriptTests : StringSpec() {
           eval("sys_exit_wrapper(3)") shouldBe 3
         }
       }
+    }
+
+    "exit guards allow exit/quit method calls on bound objects" {
+      // A method call via `.` (e.g. obj.exit()) is a user method, not the Python builtin, so it must
+      // not be rejected. Previously the (?<!\w) lookbehind wrongly matched it because `.` is not a word char.
+      val widget = Exitable()
+      PythonScript().use {
+        it.apply {
+          add("widget", widget)
+          shouldNotThrow<ScriptException> { eval("widget.exit()") }
+          shouldNotThrow<ScriptException> { eval("widget.quit()") }
+        }
+      }
+      // Both calls were allowed through the guard and actually executed on the bound object.
+      widget.calls shouldBe 2
     }
 
     "expr evaluator" {


### PR DESCRIPTION
## Summary

The `System.exit`/`exit()` guards across the three scripting engines were brittle, inconsistent, and in places nearly dead code. This hardens and centralizes them, fixes a real false-positive, and — importantly — documents honestly that they are a **best-effort convenience, not a security sandbox**.

### Problems fixed
- **Kotlin**: matched the literal `"java.lang.System.exit"` substring (the real protection for bare `System.exit` is the shadow `System` object), and missed `exitProcess(...)` and `Runtime.getRuntime().exit/halt(...)` — bypasses that *actually terminate the JVM*.
- **Java**: `eval` scanned only the `expr`, never the `action` block; `evalScript` had **no guard at all**; `Runtime.exit/halt` slipped through. (The old "illegal calls" test only passed because `sys.exit`/`exit`/`quit` are invalid Java — a compile error, not the guard firing.)
- **Python**: `(?<!\w)exit\s*\(` wrongly rejected `obj.exit()` (a method call on a user object), and missed `raise SystemExit` (the idiom underlying `sys.exit()`).

### Changes
- New **`ScriptGuards`** in `script-utils-common` (shared by Kotlin + Java): detects `System.exit`, bare & qualified `exitProcess`, and `Runtime.getRuntime().exit/halt` — including a **statically-imported bare `getRuntime().halt(0)`** (found by adversarial review) — all whitespace-tolerant, scanning all fragments together so a call in a Java `action` block is caught.
- **Kotlin/Java** engines delegate to `ScriptGuards`; Java now scans `expr`+`action` and guards `evalScript`.
- **Python**: lookbehind fixed to `(?<![\w.])` (allows `obj.exit()`), plus a `raise SystemExit` guard.
- Honest KDoc on all three engines + `ScriptGuards` stating these are **not** a sandbox; removed a duplicated KDoc note in `JavaScript`.

### Testing safety
A test that *executed* `System.exit`/`Runtime.halt` would kill the test JVM. So `ScriptGuards` is unit-tested in **isolation** (it only matches strings, never runs scripts), proving every dangerous form is rejected *before* `eval`. Only then do the engine integration tests feed real termination calls through `eval` — the guard provably throws first. The Python `obj.exit()` fix was verified RED on the old regex.

### Review
Put through a 3-lens adversarial red-team (JVM false-positives, JVM cheap bypasses, Python). The two genuinely worth-fixing findings — the static-import `getRuntime()` bypass and `raise SystemExit` — are incorporated. Unfixable-by-construction false positives (a user function literally named `exitProcess`/`exit`) are documented as accepted best-effort limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)