### PR TITLE
Broaden email validation to accept plus-addressing, long TLDs, single-char labels

### DIFF
--- a/email-utils/src/main/kotlin/com/pambrose/common/email/EmailUtils.kt
+++ b/email-utils/src/main/kotlin/com/pambrose/common/email/EmailUtils.kt
@@ -34,18 +34,23 @@ import kotlinx.html.unsafe
  */
 object EmailUtils {
   private val emailPattern by lazy {
-    Pattern.compile(
-      "^(([\\w-]+\\.)+[\\w-]+|([a-zA-Z]|[\\w-]{2,}))@" +
-        "((([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\\.([0-1]?" +
-        "[0-9]{1,2}|25[0-5]|2[0-4][0-9])\\." +
-        "([0-1]?[0-9]{1,2}|25[0-5]|2[0-4][0-9])\\.([0-1]?" +
-        "[0-9]{1,2}|25[0-5]|2[0-4][0-9]))|" +
-        "([a-zA-Z]+[\\w-]+\\.)+[a-zA-Z]{2,4})$",
-    )
+    // A practical, permissive validator (not full RFC 5322). The local part accepts the common
+    // specials, including plus-addressing (`user+tag`). The domain accepts single-character labels
+    // and modern long TLDs, or a bare IPv4 literal.
+    val localPart = "[A-Za-z0-9._%+-]+"
+    val domainName = "([A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z]{2,63}"
+    val octet = "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+    val ipv4 = "$octet(\\.$octet){3}"
+    Pattern.compile("^$localPart@($domainName|$ipv4)$")
   }
 
   /**
-   * Returns `true` if this [String] matches a valid email address pattern.
+   * Returns `true` if this [String] looks like a valid email address.
+   *
+   * This is a pragmatic, permissive check rather than a full RFC 5322 implementation: it accepts the
+   * common local-part characters (letters, digits, and `._%+-`, so plus-addressing works), single-character
+   * domain labels, modern long TLDs, and bare IPv4-literal domains. It does not accept quoted local parts,
+   * internationalized (Unicode) domains, or bracketed/IPv6 address literals.
    */
   fun String.isValidEmail() = emailPattern.matcher(this).matches()
 

--- a/email-utils/src/test/kotlin/com/pambrose/common/email/EmailUtilsTests.kt
+++ b/email-utils/src/test/kotlin/com/pambrose/common/email/EmailUtilsTests.kt
@@ -32,8 +32,15 @@ class EmailUtilsTests : StringSpec() {
     "is valid email simple" {
       "test@example.com".isValidEmail() shouldBe true
       "user.name@domain.org".isValidEmail() shouldBe true
-      // Note: The email pattern doesn't support + character in local part
       "user@example.co.uk".isValidEmail() shouldBe true
+    }
+
+    "accepts plus-addressing, long TLDs, and single-character domain labels" {
+      "user+tag@example.com".isValidEmail() shouldBe true
+      "first.last+filter@example.com".isValidEmail() shouldBe true
+      "user@x.io".isValidEmail() shouldBe true
+      "user@example.travel".isValidEmail() shouldBe true
+      "user@sub.example.photography".isValidEmail() shouldBe true
     }
 
     "is valid email with subdomain" {


### PR DESCRIPTION
## Summary

`isValidEmail()`'s hand-rolled regex produced false negatives on legitimate addresses:
- **plus-addressing** (`user+tag@example.com`) — `+` wasn't allowed in the local part
- **long TLDs** (`.travel`, `.email`, `.photography`) — the final label was capped at `[a-zA-Z]{2,4}`
- **single-character domain labels** (`user@x.io`) — each label required ≥ 2 chars

For a published library whose sole validation entry point this is, that rejected real user addresses.

## Fix
Replaced the regex with a pragmatic, permissive pattern, built from named parts for readability:
- local part `[A-Za-z0-9._%+-]+` (covers plus-addressing and common specials)
- hostname labels allowing single characters and interior hyphens, with a `{2,63}`-letter TLD
- or a bare IPv4 literal (preserving the previous IPv4 support)

It is intentionally **not** full RFC 5322, and the KDoc now documents what it does and does not accept (no quoted local parts, Unicode domains, or bracketed/IPv6 literals).

## Tests
New case asserts plus-addressing, long TLDs, and single-char labels are accepted — verified RED on the old regex (`expected:<true> but was:<false>`). Every existing "is not valid" assertion (missing local/domain, embedded spaces, blank) still passes, so the broadening didn't introduce false positives.

`:email-utils:check` + Kotlinter + Detekt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)