### PR TITLE
Validate SamplerGaugeCollector label sizes at construction

### DIFF
--- a/prometheus-utils/src/main/kotlin/com/pambrose/common/metrics/SamplerGaugeCollector.kt
+++ b/prometheus-utils/src/main/kotlin/com/pambrose/common/metrics/SamplerGaugeCollector.kt
@@ -30,6 +30,7 @@ import io.prometheus.client.Collector
  * @param labelNames the label names for the metric. Defaults to empty.
  * @param labelValues the label values corresponding to [labelNames]. Defaults to empty.
  * @param data a lambda that returns the current gauge value as a [Double].
+ * @throws IllegalArgumentException if [labelNames] and [labelValues] differ in size.
  */
 class SamplerGaugeCollector(
   private val name: String,
@@ -39,6 +40,11 @@ class SamplerGaugeCollector(
   private val data: () -> Double,
 ) : Collector() {
   init {
+    // Validate eagerly: otherwise MetricFamilySamples.Sample throws on every collect() (i.e. every
+    // Prometheus scrape), far from the construction site, taking down the whole scrape.
+    require(labelNames.size == labelValues.size) {
+      "labelNames (${labelNames.size}) and labelValues (${labelValues.size}) must have the same size"
+    }
     register<Collector>()
   }
 

--- a/prometheus-utils/src/test/kotlin/com/pambrose/common/metrics/SamplerGaugeCollectorTests.kt
+++ b/prometheus-utils/src/test/kotlin/com/pambrose/common/metrics/SamplerGaugeCollectorTests.kt
@@ -18,10 +18,12 @@
 
 package com.pambrose.common.metrics
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.prometheus.client.Collector
 
 class SamplerGaugeCollectorTests : StringSpec() {
@@ -58,6 +60,20 @@ class SamplerGaugeCollectorTests : StringSpec() {
       samples[0].samples[0].labelNames shouldBe listOf("region", "instance")
       samples[0].samples[0].labelValues shouldBe listOf("us-east-1", "i-12345")
       samples[0].samples[0].value shouldBe 55.5
+    }
+
+    "rejects mismatched label names and values at construction" {
+      // Previously the mismatch was undetected until MetricFamilySamples.Sample threw on every scrape.
+      val ex = shouldThrow<IllegalArgumentException> {
+        SamplerGaugeCollector(
+          name = "test_sampler_gauge_mismatch",
+          help = "mismatched labels",
+          labelNames = listOf("region", "instance"),
+          labelValues = listOf("us-east-1"),
+          data = { 1.0 },
+        )
+      }
+      ex.message shouldContain "label"
     }
 
     "sampler gauge collector dynamic value" {


### PR DESCRIPTION
## Summary

`SamplerGaugeCollector`'s `labelNames` and `labelValues` were independent constructor parameters with no size check. A mismatch wasn't caught at construction; instead `MetricFamilySamples.Sample(...)` threw `IllegalArgumentException` on **every `collect()` — i.e. every Prometheus scrape** — surfacing far from the construction site and taking down the entire scrape (all other metrics with it).

## Fix
Add a `require(labelNames.size == labelValues.size)` at the top of the `init` block, **before** the collector registers itself, so a mismatch fails fast at construction with a clear message (and a broken collector is never registered). KDoc gains an `@throws`.

## Tests
New case asserts construction with mismatched label sizes throws `IllegalArgumentException` (message mentions "label") — verified RED on the old code (`no exception was thrown`). The existing happy-path tests (no labels, matching labels, dynamic value) still pass.

`:prometheus-utils:check` + Kotlinter + Detekt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)