### PR TITLE
Support concurrent waiters in GenericValueWaiter/BooleanWaiter

### DIFF
--- a/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/GenericValueWaiter.kt
+++ b/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/GenericValueWaiter.kt
@@ -16,148 +16,169 @@
 
 package com.pambrose.common.concurrent
 
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 /**
- * A coroutine-based waiter that suspends until a boolean value changes.
+ * A coroutine-based waiter that suspends until a boolean value satisfies a condition.
  *
- * Extends [GenericValueWaiter] to provide [waitUntilTrue] and [waitUntilFalse]
- * convenience methods with optional timeout support.
+ * Provides [waitUntilTrue] and [waitUntilFalse] convenience methods with optional timeout support.
+ * Any number of coroutines may wait concurrently; each is resumed independently when its own
+ * condition is met.
  *
  * @param initValue the initial boolean value.
  */
 class BooleanWaiter(
   initValue: Boolean,
 ) : GenericValueWaiter<Boolean>(initValue) {
-  @Volatile
-  private var predicate: () -> Boolean = { currValue != initValue }
-
-  override fun monitorSatisfied() = predicate()
-
   /**
-   * Sets the boolean value and notifies any waiting coroutines if the condition is satisfied.
+   * Sets the boolean value and resumes any waiting coroutines whose condition is now satisfied.
    *
    * @param value the new boolean value.
    */
-  suspend fun setValue(value: Boolean) {
-    checkCondition(value)
-  }
+  fun setValue(value: Boolean) = checkCondition(value)
 
   /**
-   * Suspends until the value becomes `true` or the timeout expires.
+   * Suspends until the value is (or becomes) `true`, or the timeout expires.
    *
    * @param timeoutDuration the maximum duration to wait. Defaults to [Duration.INFINITE].
-   * @return `true` if the value became `true` before the timeout, `false` if the timeout expired.
+   * @return `true` if the value was `true` before the timeout, `false` if the timeout expired.
    */
-  suspend fun waitUntilTrue(timeoutDuration: Duration = Duration.INFINITE): Boolean {
-    predicate = { currValue }
-    return waitForCondition(timeoutDuration)
-  }
+  suspend fun waitUntilTrue(timeoutDuration: Duration = Duration.INFINITE): Boolean =
+    waitForCondition({ currValue }, timeoutDuration)
 
   /**
-   * Suspends until the value becomes `false` or the timeout expires.
+   * Suspends until the value is (or becomes) `false`, or the timeout expires.
    *
    * @param timeoutDuration the maximum duration to wait. Defaults to [Duration.INFINITE].
-   * @return `true` if the value became `false` before the timeout, `false` if the timeout expired.
+   * @return `true` if the value was `false` before the timeout, `false` if the timeout expired.
    */
-  suspend fun waitUntilFalse(timeoutDuration: Duration = Duration.INFINITE): Boolean {
-    predicate = { !currValue }
-    return waitForCondition(timeoutDuration)
-  }
+  suspend fun waitUntilFalse(timeoutDuration: Duration = Duration.INFINITE): Boolean =
+    waitForCondition({ !currValue }, timeoutDuration)
 }
 
 /**
- * Abstract coroutine-based waiter that suspends until a monitored value satisfies a condition.
+ * Abstract coroutine-based waiter that suspends callers until a per-call condition is satisfied.
  *
- * Subclasses define the satisfaction condition via [monitorSatisfied]. The value can be updated
- * with [checkCondition], which notifies any waiting coroutine when the condition is met.
+ * Each call to [waitForCondition] registers its own predicate and continuation, so any number of
+ * coroutines may wait concurrently — each on a possibly-different condition — and each is resumed
+ * independently. [checkCondition] updates the monitored value and resumes every registered waiter
+ * whose predicate is now satisfied.
+ *
+ * It is `abstract` by design — a base class for typed waiters (such as [BooleanWaiter]) that expose the
+ * protected [waitForCondition] through their own typed wait methods — even though it declares no abstract
+ * members, since each wait supplies its own predicate.
  *
  * @param T the type of the monitored value.
  * @param initValue the initial value.
  */
+@Suppress("AbstractClassCanBeConcreteClass")
 abstract class GenericValueWaiter<T>(
   protected val initValue: T,
 ) {
-  private val mutex = Mutex()
-  private var onConditionChanged: (() -> Unit)? = null
+  private val lock = ReentrantLock()
+  private val waiters = mutableListOf<Waiter>()
 
   protected var currValue = initValue
 
-  protected abstract fun monitorSatisfied(): Boolean
+  private class Waiter(
+    val predicate: () -> Boolean,
+    val continuation: CancellableContinuation<Boolean>,
+  ) {
+    var timeoutJob: Job? = null
+  }
 
   /**
-   * Suspends until the condition becomes true.
+   * Suspends until [predicate] holds for the current value, or [timeoutDuration] expires.
+   *
+   * [predicate] is evaluated immediately (under the lock) and again on each [checkCondition]; it
+   * should read only the monitored value, not block or suspend.
+   *
+   * @param predicate the condition this caller is waiting for.
+   * @param timeoutDuration the maximum duration to wait; a non-finite duration waits indefinitely.
+   * @return `true` if the predicate was satisfied, `false` if the timeout expired.
    */
-  protected suspend fun waitForCondition(timeoutDuration: Duration): Boolean =
+  protected suspend fun waitForCondition(
+    predicate: () -> Boolean,
+    timeoutDuration: Duration,
+  ): Boolean =
     coroutineScope {
       suspendCancellableCoroutine { continuation ->
-        val timeoutJob = launch {
-          delay(timeoutDuration)
-          mutex.withLock {
-            onConditionChanged = null
-            continuation.resume(false)
-          }
-        }
+        val waiter = Waiter(predicate, continuation)
 
-        launch {
-          mutex.withLock {
-            if (monitorSatisfied()) {
-              timeoutJob.cancel()
-              continuation.resume(true)
+        val alreadySatisfied =
+          lock.withLock {
+            if (predicate()) {
+              true
             } else {
-              onConditionChanged = {
-                continuation.resume(true)
-                timeoutJob.cancel()
+              // Arm the timeout and register the waiter under the same lock. checkCondition removes the
+              // waiter under this lock too, so it is guaranteed to observe a non-null timeoutJob and
+              // cancel it; otherwise a satisfied waiter could stall until the full timeout elapsed,
+              // because the structured coroutineScope cannot return while the orphaned delay is running.
+              if (timeoutDuration.isFinite()) {
+                waiter.timeoutJob =
+                  launch {
+                    delay(timeoutDuration)
+                    if (lock.withLock { waiters.remove(waiter) })
+                      continuation.resume(false)
+                  }
               }
+              waiters += waiter
+              false
             }
           }
-        }
 
-        continuation.invokeOnCancellation {
-          timeoutJob.cancel()
-          onConditionChanged = null
+        if (alreadySatisfied) {
+          continuation.resume(true)
+        } else {
+          continuation.invokeOnCancellation {
+            lock.withLock { waiters.remove(waiter) }
+          }
         }
       }
     }
 
   /**
-   * Updates the value and then checks the condition to see if it's satisfied.
+   * Updates the monitored value and resumes every waiting coroutine whose predicate is now satisfied.
+   *
+   * @param value the new value.
    */
-  suspend fun checkCondition(value: T) {
-    mutex.withLock {
+  fun checkCondition(value: T) {
+    val satisfied = mutableListOf<Waiter>()
+    val failed = mutableListOf<Pair<Waiter, Throwable>>()
+    lock.withLock {
       currValue = value
-      if (monitorSatisfied()) {
-        onConditionChanged?.invoke() // Notify waiting coroutine
-        onConditionChanged = null // Clear the callback
+      // Evaluate each predicate in isolation so a single misbehaving one cannot starve the others, and
+      // cancel the timeout job under the lock (where it is guaranteed visible) before the waiter resumes.
+      waiters.removeAll { waiter ->
+        runCatching { waiter.predicate() }.fold(
+          onSuccess = { matched ->
+            if (matched) {
+              waiter.timeoutJob?.cancel()
+              satisfied += waiter
+            }
+            matched
+          },
+          onFailure = { error ->
+            waiter.timeoutJob?.cancel()
+            failed += waiter to error
+            true
+          },
+        )
       }
     }
+    // Resume outside the lock so a resumed coroutine that re-enters cannot deadlock. Each waiter was
+    // removed from the list exactly once (under the lock), so it is resumed at most once.
+    satisfied.forEach { it.continuation.resume(true) }
+    failed.forEach { (waiter, error) -> waiter.continuation.resumeWithException(error) }
   }
 }
-
-fun main() =
-  runBlocking {
-    val waiter = BooleanWaiter(true)
-
-    // Launch a coroutine that waits for the condition to become true
-    launch {
-      println("Waiting for condition to become true...")
-      waiter.waitUntilFalse(20.seconds).also { if (!it) println("Timed out") }
-      println("Condition is now true!")
-    }
-
-    delay(5.seconds)
-    println("Setting condition to true.")
-    waiter.setValue(false)
-
-    delay(15.seconds)
-    println("Finished.")
-  }

--- a/guava-utils/src/test/kotlin/com/pambrose/common/concurrent/BugFixVerificationTests.kt
+++ b/guava-utils/src/test/kotlin/com/pambrose/common/concurrent/BugFixVerificationTests.kt
@@ -73,8 +73,9 @@ class BugFixVerificationTests : StringSpec() {
     }
 
     // Bug #16: Race condition in GenericValueWaiter/BooleanWaiter
-    // Before fix: check and callback setup were not atomic; predicate was not volatile
-    // After fix: check and callback are set atomically under mutex; predicate is @Volatile
+    // The waiter now registers a per-call (predicate, continuation) under a lock and resumes each
+    // waiter independently, so concurrent waiters are no longer lost. (See GenericValueWaiterTests
+    // for the concurrent-waiter coverage.)
 
     "boolean waiter wait until true works" {
       val waiter = BooleanWaiter(false)

--- a/guava-utils/src/test/kotlin/com/pambrose/common/concurrent/GenericValueWaiterTests.kt
+++ b/guava-utils/src/test/kotlin/com/pambrose/common/concurrent/GenericValueWaiterTests.kt
@@ -1,16 +1,102 @@
-@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction", "InjectDispatcher")
 
 package com.pambrose.common.concurrent
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+// Test-only subclass exposing the protected waitForCondition with an arbitrary predicate.
+private class IntWaiter(
+  init: Int,
+) : GenericValueWaiter<Int>(init) {
+  val current get() = currValue
+
+  suspend fun awaitValue(predicate: () -> Boolean) = waitForCondition(predicate, Duration.INFINITE)
+}
 
 class GenericValueWaiterTests : StringSpec() {
   init {
+    "a satisfied waiter resumes promptly rather than stalling for the full timeout" {
+      // Races registering a waiter against satisfying it, with a long timeout. If checkCondition cannot
+      // see (and cancel) the timeout job when it removes the waiter, the satisfied wait stalls until the
+      // timeout elapses because the structured coroutineScope waits for the orphaned delay.
+      withContext(Dispatchers.Default) {
+        repeat(200) {
+          val waiter = BooleanWaiter(false)
+          val job = launch { waiter.waitUntilTrue(5.seconds) }
+          launch { waiter.setValue(true) }
+          val mark = TimeSource.Monotonic.markNow()
+          job.join()
+          (mark.elapsedNow() < 2.seconds) shouldBe true
+        }
+      }
+    }
+
+    "a throwing predicate fails only its own waiter, not the others" {
+      val waiter = IntWaiter(0)
+      var goodResult: Boolean? = null
+      var badError: Throwable? = null
+
+      val good = launch { goodResult = waiter.awaitValue { waiter.current == 1 } }
+      val bad =
+        launch {
+          runCatching { waiter.awaitValue { if (waiter.current == 1) error("boom") else false } }
+            .onFailure { badError = it }
+        }
+      delay(50.milliseconds)
+
+      waiter.checkCondition(1)
+      good.join()
+      bad.join()
+
+      goodResult shouldBe true
+      badError!!.message shouldContain "boom"
+    }
+
+    "multiple coroutines waiting on the same condition are all resumed" {
+      val waiter = BooleanWaiter(false)
+      val results = CopyOnWriteArrayList<Boolean>()
+
+      val jobs =
+        (1..3).map {
+          launch { results += waiter.waitUntilTrue(1.seconds) }
+        }
+
+      delay(100.milliseconds)
+      waiter.setValue(true)
+      jobs.forEach { it.join() }
+
+      // Every waiter must be resumed with true; the old single-slot callback resumed only the last.
+      results.size shouldBe 3
+      results.all { it } shouldBe true
+    }
+
+    "a waiting waitUntilTrue is not clobbered by a concurrent waitUntilFalse" {
+      val waiter = BooleanWaiter(false)
+      var aResult: Boolean? = null
+
+      val a = launch { aResult = waiter.waitUntilTrue(1.seconds) }
+      delay(50.milliseconds)
+
+      // The value is already false, so this returns immediately. On the old code it overwrote the
+      // single shared predicate, so the still-waiting waitUntilTrue then missed the value becoming true.
+      waiter.waitUntilFalse(1.seconds) shouldBe true
+
+      waiter.setValue(true)
+      a.join()
+      aResult shouldBe true
+    }
+
     "BooleanWaiter setValue and waitUntilTrue work correctly" {
       val waiter = BooleanWaiter(false)
       var completed = false


### PR DESCRIPTION
## Summary

`GenericValueWaiter` used a single nullable `onConditionChanged` callback, and `BooleanWaiter` a single shared `@Volatile predicate`, so concurrent waiters clobbered each other:
- A second `waitForCondition` overwrote the first's callback — **the first waiter was silently lost** (it could only ever return via timeout).
- A concurrent `waitUntilTrue` / `waitUntilFalse` overwrote the shared predicate, so a still-waiting waiter could **miss the value it was waiting for**.

## Fix
Each wait now registers its own `(predicate, continuation)` in a list under a `ReentrantLock`; `checkCondition` resumes **every** waiter whose predicate is satisfied. The abstract `monitorSatisfied()` is gone — the predicate is passed per `waitForCondition` call.

- `BooleanWaiter`'s public API (`waitUntilTrue`/`waitUntilFalse`/`setValue`) is unchanged.
- `setValue`/`checkCondition` are no longer `suspend` (they no longer suspend) — they can now be called from any thread.
- A timeout coroutine is armed only for a finite timeout (no more `delay(Duration.INFINITE)`).
- Removed the dead `fun main()` demo that shipped in the JAR.

## Adversarial review caught two more real defects (both fixed + regression-tested)
The rewrite went through a 3-lens concurrency red-team, which empirically found:
1. **Liveness (high):** the timeout job was armed *outside* the lock, so `checkCondition` could remove a satisfied waiter before the `timeoutJob` field was visible, fail to cancel it, and let the orphaned `delay` block the structured `coroutineScope` until the **full timeout** — a *satisfied* wait could stall for seconds. Fixed by arming the timeout (and registering the waiter) under the same lock and cancelling it under the lock.
2. **Predicate isolation (medium):** a predicate that threw inside `checkCondition` aborted the whole notification pass, starving the other waiters. Each predicate is now evaluated in isolation; a throwing predicate fails only its own waiter (`resumeWithException`).

## Tests
New `GenericValueWaiterTests` cases, each **verified RED on the buggy code then GREEN**:
- multiple concurrent waiters all resumed (single-slot callback bug)
- a `waitUntilTrue` not clobbered by a concurrent `waitUntilFalse` (shared-predicate bug)
- a satisfied waiter resumes promptly rather than stalling for the full timeout (200-iteration stress on `Dispatchers.Default`; caught the liveness bug at `expected:<true> but was:<false>`)
- a throwing predicate fails only its own waiter (caught the non-isolated pass propagating the exception)

The existing `BugFixVerificationTests` (Bug #16) still pass; its now-stale comment is updated. `:guava-utils:check` + Kotlinter + Detekt all green.

`LameBooleanWaiter` has the same class of single-slot bug and is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)