### PR TITLE
Fix three medium-severity correctness findings (unzip charset, obfuscate guard, sampler exception)

### DIFF
--- a/core-utils/src/main/kotlin/com/pambrose/common/util/StringExtensions.kt
+++ b/core-utils/src/main/kotlin/com/pambrose/common/util/StringExtensions.kt
@@ -458,8 +458,12 @@ fun String.maskUrlCredentials() =
  *
  * @param freq the replacement frequency (default every 2nd character, starting at index 0)
  * @return the obfuscated string
+ * @throws IllegalArgumentException if [freq] is not positive (it is used as a modulus divisor).
  */
-fun String.obfuscate(freq: Int = 2) = mapIndexed { i, v -> if (i % freq == 0) '*' else v }.joinToString("")
+fun String.obfuscate(freq: Int = 2): String {
+  require(freq > 0) { "freq must be positive but was $freq" }
+  return mapIndexed { i, v -> if (i % freq == 0) '*' else v }.joinToString("")
+}
 
 /**
  * Truncates this [String] to at most [len] characters.

--- a/core-utils/src/test/kotlin/com/pambrose/util/StringExtensionEdgeCaseTests.kt
+++ b/core-utils/src/test/kotlin/com/pambrose/util/StringExtensionEdgeCaseTests.kt
@@ -30,6 +30,7 @@ import com.pambrose.common.util.pathOf
 import com.pambrose.common.util.sha256
 import com.pambrose.common.util.substringBetween
 import com.pambrose.common.util.withLineNumbers
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -127,6 +128,10 @@ class StringExtensionEdgeCaseTests : StringSpec() {
       "hello".obfuscate(3) shouldBe "*el*o" // freq=3: positions 0,3 replaced
       "ab".obfuscate() shouldBe "*b"
       "".obfuscate() shouldBe ""
+      "abc".obfuscate(1) shouldBe "***" // freq=1: every position replaced
+      // freq must be positive; a non-positive freq previously threw ArithmeticException (i % 0).
+      shouldThrow<IllegalArgumentException> { "abc".obfuscate(0) }
+      shouldThrow<IllegalArgumentException> { "abc".obfuscate(-1) }
     }
 
     "max length test" {

--- a/guava-utils/src/main/kotlin/com/pambrose/common/util/ZipExtensions.kt
+++ b/guava-utils/src/main/kotlin/com/pambrose/common/util/ZipExtensions.kt
@@ -86,7 +86,9 @@ fun ByteArray.unzip(): String =
     }
 
     !isZipped() -> {
-      String(this)
+      // Decode explicitly as UTF-8 to match the encoding side ([String.zip] / [ByteArray.zip]); the
+      // bare String(this) used the JVM default charset and corrupted non-ASCII content on non-UTF-8 JVMs.
+      String(this, StandardCharsets.UTF_8)
     }
 
     else -> {

--- a/guava-utils/src/test/kotlin/com/pambrose/util/ZipExtensionTests.kt
+++ b/guava-utils/src/test/kotlin/com/pambrose/util/ZipExtensionTests.kt
@@ -16,6 +16,7 @@
 
 package com.pambrose.util
 
+import com.pambrose.common.util.isZipped
 import com.pambrose.common.util.unzip
 import com.pambrose.common.util.zip
 import io.kotest.core.spec.style.StringSpec
@@ -63,6 +64,14 @@ class ZipExtensionTests : StringSpec() {
     "empty byte array zip test" {
       ByteArray(0).zip() shouldBe ByteArray(0)
       ByteArray(0).zip().unzip() shouldBe ""
+    }
+
+    "unzip decodes non-gzipped bytes as UTF-8, not the platform default charset" {
+      val s = "héllo wörld 世界"
+      val raw = s.toByteArray(Charsets.UTF_8)
+      raw.isZipped() shouldBe false
+      // Locks the UTF-8 contract for the passthrough branch; previously it used the JVM default charset.
+      raw.unzip() shouldBe s
     }
   }
 }

--- a/prometheus-utils/src/main/kotlin/com/pambrose/common/metrics/SamplerGaugeCollector.kt
+++ b/prometheus-utils/src/main/kotlin/com/pambrose/common/metrics/SamplerGaugeCollector.kt
@@ -17,6 +17,7 @@
 
 package com.pambrose.common.metrics
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.prometheus.client.Collector
 
 /**
@@ -49,7 +50,18 @@ class SamplerGaugeCollector(
   }
 
   override fun collect(): List<MetricFamilySamples> {
-    val sample = MetricFamilySamples.Sample(name, labelNames, labelValues, data())
+    // collect() runs on every Prometheus scrape; a throwing sampler must not abort the whole scrape
+    // (taking down every other metric), so guard it and report NaN instead.
+    val value =
+      runCatching { data() }.getOrElse { e ->
+        logger.warn(e) { "Sampler for metric \"$name\" threw; reporting NaN" }
+        Double.NaN
+      }
+    val sample = MetricFamilySamples.Sample(name, labelNames, labelValues, value)
     return listOf(MetricFamilySamples(name, Type.GAUGE, help, listOf(sample)))
+  }
+
+  companion object {
+    private val logger = KotlinLogging.logger {}
   }
 }

--- a/prometheus-utils/src/test/kotlin/com/pambrose/common/metrics/SamplerGaugeCollectorTests.kt
+++ b/prometheus-utils/src/test/kotlin/com/pambrose/common/metrics/SamplerGaugeCollectorTests.kt
@@ -91,5 +91,16 @@ class SamplerGaugeCollectorTests : StringSpec() {
       (value2 - value1) shouldBe 1.0
       (value3 - value2) shouldBe 1.0
     }
+
+    "a throwing sampler reports NaN instead of aborting the scrape" {
+      val collector = SamplerGaugeCollector(
+        name = "test_sampler_gauge_throws",
+        help = "throwing sampler",
+        data = { throw RuntimeException("boom") },
+      )
+      // collect() must not propagate the sampler's exception (that would take down the whole scrape).
+      val samples = collector.collect()
+      samples[0].samples[0].value.isNaN() shouldBe true
+    }
   }
 }


### PR DESCRIPTION
Three small, independent correctness fixes from the codebase review, bundled like the prior `#117` multi-module review batch.

## 1. `ByteArray.unzip()` decoded non-gzipped bytes with the platform default charset — guava-utils
The GZIP branch decodes UTF-8 and `zip()` encodes UTF-8, but the non-gzipped passthrough used `String(this)` (the JVM default charset). On a non-UTF-8 JVM (some Windows configs, or `-Dfile.encoding` overrides) this corrupts non-ASCII content and breaks round-tripping with bytes produced via `toByteArray(UTF_8)`. Now decodes explicitly as `String(this, StandardCharsets.UTF_8)`.

## 2. `String.obfuscate()` threw `ArithmeticException` for `freq <= 0` — core-utils
`obfuscate` computes `i % freq`; a `freq` of 0 threw `ArithmeticException: / by zero` from a public API (and a negative `freq` gave surprising modulo semantics). Added `require(freq > 0)` and a `@throws` to the KDoc.

## 3. `SamplerGaugeCollector` sampler exception aborted the whole scrape — prometheus-utils (sibling to #125)
`data()` is invoked synchronously inside `collect()`, which Prometheus calls on every scrape. A throwing sampler propagated out of `collect()` and aborted the entire registry scrape (taking down all other metrics). Now guarded with `runCatching` — it logs the failure with the metric name and reports `Double.NaN` so the rest of the scrape survives.

## Tests
- `obfuscate(0)`/`obfuscate(-1)` now throw `IllegalArgumentException` — **verified red** on the old code (`ArithmeticException` was thrown instead); plus a `freq=1` all-masked case.
- a throwing sampler's `collect()` returns `NaN` and does not throw — **verified red** (the `RuntimeException` propagated).
- `unzip` of non-gzipped non-ASCII UTF-8 bytes round-trips — a contract/regression guard (the bug is platform-default-charset-dependent, so it can't fail on a UTF-8 JVM, but the fix makes the decode explicit and correct everywhere).

`:guava-utils:check`, `:core-utils:check`, `:prometheus-utils:check` + Kotlinter + Detekt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)