### PR TITLE
Idiomatic Kotlin and small performance improvements

### DIFF
--- a/core-utils/src/main/kotlin/com/pambrose/common/util/Banner.kt
+++ b/core-utils/src/main/kotlin/com/pambrose/common/util/Banner.kt
@@ -43,7 +43,7 @@ fun getBanner(
   var first = -1
   var last = -1
   lines.forEachIndexed { index, line ->
-    if (line.trim { arg -> arg <= ' ' }.isNotEmpty()) {
+    if (line.isNotBlank()) {
       if (first == -1)
         first = index
       last = index

--- a/core-utils/src/main/kotlin/com/pambrose/common/util/StringExtensions.kt
+++ b/core-utils/src/main/kotlin/com/pambrose/common/util/StringExtensions.kt
@@ -245,37 +245,19 @@ fun String.asBracketed(
 ) = "$startChar$this$endChar"
 
 /** Returns `true` if this [String] can be parsed as an [Int]. */
-fun String.isInt() =
-  try {
-    this.toInt()
-    true
-  } catch (e: Exception) {
-    false
-  }
+fun String.isInt() = toIntOrNull() != null
 
 /** Returns `true` if this [String] cannot be parsed as an [Int]. */
 fun String.isNotInt() = !isInt()
 
 /** Returns `true` if this [String] can be parsed as a [Float]. */
-fun String.isFloat() =
-  try {
-    this.toFloat()
-    true
-  } catch (e: Exception) {
-    false
-  }
+fun String.isFloat() = toFloatOrNull() != null
 
 /** Returns `true` if this [String] cannot be parsed as a [Float]. */
 fun String.isNotFloat() = !isFloat()
 
 /** Returns `true` if this [String] can be parsed as a [Double]. */
-fun String.isDouble() =
-  try {
-    this.toDouble()
-    true
-  } catch (e: Exception) {
-    false
-  }
+fun String.isDouble() = toDoubleOrNull() != null
 
 /** Returns `true` if this [String] cannot be parsed as a [Double]. */
 fun String.isNotDouble() = !isDouble()
@@ -381,7 +363,7 @@ fun String.sha256(salt: ByteArray): String = encodedByteArray(this, salt, "SHA-2
  * Extension property on [ByteArray].
  */
 @Suppress("ImplicitDefaultLocale")
-val ByteArray.asText get() = fold("") { str, byte -> str + "%02x".format(byte) }
+val ByteArray.asText get() = joinToString("") { "%02x".format(it) }
 
 private fun encodedByteArray(
   input: String,

--- a/email-utils/src/main/kotlin/com/pambrose/common/email/ResendService.kt
+++ b/email-utils/src/main/kotlin/com/pambrose/common/email/ResendService.kt
@@ -63,9 +63,9 @@ class ResendService(
         }
       val response: CreateEmailResponse = resend.emails().send(request)
 
-      val toStr = to.joinToString(", ").let { it.ifBlank { "None" } }
-      val ccStr = cc.joinToString(", ").let { it.ifBlank { "None" } }
-      val bccStr = bcc.joinToString(", ").let { it.ifBlank { "None" } }
+      val toStr = to.joinToString(", ").ifBlank { "None" }
+      val ccStr = cc.joinToString(", ").ifBlank { "None" }
+      val bccStr = bcc.joinToString(", ").ifBlank { "None" }
       logger.info { "Sent email to: $toStr cc: $ccStr bcc: $bccStr [${response.id}]" }
     }.onFailure { e ->
       logger.error(e) { "sendEmail() error: ${e.message}" }

--- a/exposed-utils/src/main/kotlin/com/pambrose/common/exposed/ExposedUtils.kt
+++ b/exposed-utils/src/main/kotlin/com/pambrose/common/exposed/ExposedUtils.kt
@@ -61,7 +61,7 @@ class KotlinSqlLogger(
  * @throws IllegalArgumentException if no field exists at the given index
  */
 operator fun ResultRow.get(index: Int) =
-  fieldIndex.filter { it.value == index }.map { this[it.key] }.firstOrNull()
+  fieldIndex.entries.firstOrNull { it.value == index }?.let { this[it.key] }
     ?: throw IllegalArgumentException("No value at index $index")
 
 /**

--- a/jetty-utils/src/main/kotlin/com/pambrose/common/dsl/JettyDsl.kt
+++ b/jetty-utils/src/main/kotlin/com/pambrose/common/dsl/JettyDsl.kt
@@ -34,7 +34,7 @@ object JettyDsl {
   fun server(
     port: Int,
     block: Server.() -> Unit,
-  ) = Server(port).apply { block(this) }
+  ) = Server(port).apply(block)
 
   /**
    * Creates and configures a [ServletContextHandler].
@@ -42,5 +42,5 @@ object JettyDsl {
    * @param block a lambda with [ServletContextHandler] as receiver for adding servlets and filters.
    * @return the configured [ServletContextHandler] instance.
    */
-  fun servletContextHandler(block: ServletContextHandler.() -> Unit) = ServletContextHandler().apply { block(this) }
+  fun servletContextHandler(block: ServletContextHandler.() -> Unit) = ServletContextHandler().apply(block)
 }

--- a/json-utils/src/main/kotlin/com/pambrose/common/json/JsonElementUtils.kt
+++ b/json-utils/src/main/kotlin/com/pambrose/common/json/JsonElementUtils.kt
@@ -103,8 +103,15 @@ operator fun JsonElement.get(vararg keys: String): JsonElement =
  * @param keys one or more dot-separated key paths
  * @return the [JsonElement] at the path, or `null` if not found or [JsonNull]
  */
-fun JsonElement.getOrNull(vararg keys: String): JsonElement? =
-  if (containsKeys(*keys)) get(*keys).takeIf { it != JsonNull } else null
+fun JsonElement.getOrNull(vararg keys: String): JsonElement? {
+  // Walk the path once and short-circuit on the first missing key, instead of traversing twice
+  // (containsKeys then get).
+  var current: JsonElement? = this
+  for (key in keys.flatMap { it.split(".") }) {
+    current = (current as? JsonObject)?.get(key) ?: return null
+  }
+  return current?.takeIf { it != JsonNull }
+}
 
 // Primitive values
 
@@ -212,6 +219,9 @@ private fun prettyPrint(indent: String) =
     prettyPrintIndent = indent
   }
 
+// Cache the default (two-space) formatter so the common path doesn't rebuild a Json on every call.
+private val defaultPrettyFormat by lazy { prettyPrint("  ") }
+
 /**
  * Encodes this [JsonElement] as a pretty-printed JSON string.
  *
@@ -220,7 +230,8 @@ private fun prettyPrint(indent: String) =
  * @param indent the indentation string to use (defaults to two spaces)
  * @return the formatted JSON string
  */
-fun JsonElement.toFormattedString(indent: String = "  "): String = prettyPrint(indent).encodeToString(this)
+fun JsonElement.toFormattedString(indent: String = "  "): String =
+  if (indent == "  ") defaultPrettyFormat.encodeToString(this) else prettyPrint(indent).encodeToString(this)
 
 /** Parses this [String] as JSON and re-encodes it as a pretty-printed JSON string. Extension function on [String]. */
 fun String.toJsonString() = toJsonElement().toJsonString(true)

--- a/ktor-server-utils/src/main/kotlin/com/pambrose/common/features/HerokuHttpsRedirect.kt
+++ b/ktor-server-utils/src/main/kotlin/com/pambrose/common/features/HerokuHttpsRedirect.kt
@@ -84,7 +84,7 @@ class HerokuHttpsRedirect(
      * The list of call predicates for redirect exclusion.
      * Any call matching any of the predicates will not be redirected by this feature.
      */
-    val excludePredicates: MutableList<CallPredicate> = ArrayList()
+    val excludePredicates: MutableList<CallPredicate> = mutableListOf()
 
     /**
      * Exclude calls with paths matching the [pathPrefix] from being redirected to https by this feature.

--- a/redis-utils/src/main/kotlin/com/pambrose/common/redis/RedisUtils.kt
+++ b/redis-utils/src/main/kotlin/com/pambrose/common/redis/RedisUtils.kt
@@ -63,7 +63,6 @@ object RedisUtils {
       logger.error { FAILED_TO_CONNECT_MSG }
   }
 
-  private val colon = Regex(":")
   private val defaultRedisUrl = System.getenv("REDIS_URL") ?: "redis://user:none@localhost:6379"
 
   /**
@@ -85,11 +84,8 @@ object RedisUtils {
 
   private fun urlDetails(redisUrl: String) =
     URI(redisUrl).let {
-      RedisInfo(
-        it,
-        (it.userInfo?.split(colon, 2)?.getOrElse(0) { "" }.orEmpty()),
-        (it.userInfo?.split(colon, 2)?.getOrElse(1) { "" }.orEmpty()),
-      )
+      val userInfo = it.userInfo?.split(":", limit = 2).orEmpty()
+      RedisInfo(it, userInfo.getOrElse(0) { "" }, userInfo.getOrElse(1) { "" })
     }
 
   private val String.isSsl: Boolean get() = lowercase(Locale.getDefault()).startsWith("rediss://")
@@ -391,15 +387,13 @@ object RedisUtils {
   ): Sequence<String> =
     sequence {
       val scanParams = ScanParams().match(pattern).count(count)
-      var cursorVal = "0"
+      var cursorVal = ScanParams.SCAN_POINTER_START
       while (true) {
-        cursorVal =
-          scan(cursorVal, scanParams).run {
-            result.forEach { yield(it) }
-            cursor
-          }
-        if (cursorVal == "0")
+        val res = scan(cursorVal, scanParams)
+        res.result.forEach { yield(it) }
+        if (res.isCompleteIteration)
           break
+        cursorVal = res.cursor
       }
     }
 }

--- a/script-utils-kotlin/src/main/kotlin/com/pambrose/common/script/KotlinScript.kt
+++ b/script-utils-kotlin/src/main/kotlin/com/pambrose/common/script/KotlinScript.kt
@@ -43,7 +43,7 @@ class KotlinScript(
   nullGlobalContext: Boolean = false,
 ) : AbstractScript("kts", nullGlobalContext),
   Closeable {
-  private val imports = mutableListOf(System::class.qualifiedName)
+  private val imports = listOf(System::class.qualifiedName)
 
   /**
    * Generates Kotlin `val` declarations that retrieve bound variables from the engine's bindings
@@ -68,10 +68,10 @@ class KotlinScript(
   internal fun String.toTempName() = "${this}_tmp"
 
   /**
-   * Generates Kotlin import statements for all registered import classes.
+   * The Kotlin import statements for all registered import classes (the import list is fixed, so this
+   * is computed once).
    */
-  val importDecls: String
-    get() = imports.joinToString("\n") { "import $it" }
+  val importDecls: String by lazy { imports.joinToString("\n") { "import $it" } }
 
   @Synchronized
   fun eval(code: String): Any? {

--- a/zipkin-utils/src/main/kotlin/com/pambrose/common/dsl/ZipkinDsl.kt
+++ b/zipkin-utils/src/main/kotlin/com/pambrose/common/dsl/ZipkinDsl.kt
@@ -31,8 +31,6 @@ object ZipkinDsl {
    */
   fun tracing(block: Tracing.Builder.() -> Unit): Tracing =
     Tracing.newBuilder()
-      .run {
-        block(this)
-        build()
-      }
+      .apply(block)
+      .build()
 }


### PR DESCRIPTION
A batch of behavior-preserving idiomatic + small-perf cleanups from the codebase review (12 items across 10 modules).

## Idiomatic
- **core-utils** `isInt`/`isFloat`/`isDouble` → `toIntOrNull()/toFloatOrNull()/toDoubleOrNull() != null` (no more `catch (Exception)` control flow).
- **email-utils** drop the redundant `.let` around `ifBlank`.
- **jetty-utils / zipkin-utils** `apply(block)` / `apply(block).build()` instead of `apply { block(this) }` / `run { block(this); build() }`.
- **ktor-server-utils** `mutableListOf()` instead of `ArrayList()`.
- **redis-utils** parse `userInfo` once via `split(":", limit = 2)` (drops the compiled `Regex(":")` field and a double-split); use `ScanParams.SCAN_POINTER_START` / `ScanResult.isCompleteIteration` instead of the hardcoded `"0"` cursor sentinel.
- **exposed-utils** `ResultRow.get(index)` does a single `firstOrNull` pass instead of `filter`/`map`/`firstOrNull`.

## Performance
- **json-utils** `getOrNull` walks the key path **once** (was `containsKeys` + `get` — two full traversals, multiplied across every `*OrNull` accessor); `toFormattedString` reuses a **cached** default two-space `Json` instead of building one on every call.
- **script-utils-kotlin** `importDecls` is computed once (`by lazy`) — the import list is fixed, so it was being re-joined on every `eval`.
- **core-utils** `asText` builds the hash hex string with `joinToString` instead of `O(n²)` `fold` string concatenation.

## Verification
An adversarial behavior-equivalence review hunted for any input where the new code diverges from the old, on the non-trivial changes (`getOrNull` traversal incl. `JsonNull`/non-object/dotted keys, `asText` negative bytes, `toFormattedString` indent, number-parsing edge cases, the SCAN sentinel, `userInfo` parsing, `ResultRow.get` null-value handling). It found **no differences** for any of them.

The **one** non-identical change is `Banner`'s blank-line check: `isNotBlank()` uses Kotlin's standard whitespace definition rather than the old `char <= ' '` predicate, so it treats a line of only Unicode whitespace (e.g. NBSP) as blank and a line of only sub-`0x20` control chars as content — matching the review's recommendation, and differing only for pathological inputs that don't occur in real banners.

`check` + Kotlinter + Detekt green across all 9 affected modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)