### PR TITLE
Documentation accuracy fixes

### DIFF
--- a/dropwizard-utils/src/main/kotlin/com/pambrose/common/util/MetricsUtils.kt
+++ b/dropwizard-utils/src/main/kotlin/com/pambrose/common/util/MetricsUtils.kt
@@ -28,7 +28,7 @@ object MetricsUtils {
    * Creates a [HealthCheck] that reports unhealthy when the backlog size meets or exceeds the given threshold.
    *
    * @param backlogSize the current backlog size to evaluate.
-   * @param size the threshold above which the check is considered unhealthy.
+   * @param size the threshold at or above which the check is considered unhealthy.
    * @return a [HealthCheck] that monitors backlog size.
    */
   fun newBacklogHealthCheck(
@@ -45,7 +45,7 @@ object MetricsUtils {
    * Creates a [HealthCheck] that reports unhealthy when the map size meets or exceeds the given threshold.
    *
    * @param map the map whose size is evaluated.
-   * @param size the threshold above which the check is considered unhealthy.
+   * @param size the threshold at or above which the check is considered unhealthy.
    * @return a [HealthCheck] that monitors map size.
    */
   fun newMapHealthCheck(

--- a/exposed-utils/src/main/kotlin/com/pambrose/common/exposed/ExposedUtils.kt
+++ b/exposed-utils/src/main/kotlin/com/pambrose/common/exposed/ExposedUtils.kt
@@ -65,9 +65,11 @@ operator fun ResultRow.get(index: Int) =
     ?: throw IllegalArgumentException("No value at index $index")
 
 /**
- * Converts this [ResultRow] to a human-readable string by joining all non-empty column values with " - ".
+ * Converts this [ResultRow] to a human-readable string by joining each column's string representation
+ * with " - ", omitting columns whose string form is empty.
  *
- * Extension function on [ResultRow].
+ * Extension function on [ResultRow]. Note that a `null` column value renders as the literal text
+ * `"null"` (its `toString()`), so null columns are included rather than skipped.
  *
  * @return a formatted string of the row's values
  */

--- a/json-utils/src/main/kotlin/com/pambrose/common/json/JsonElementUtils.kt
+++ b/json-utils/src/main/kotlin/com/pambrose/common/json/JsonElementUtils.kt
@@ -269,7 +269,8 @@ inline fun <reified T> T.toJsonElement() = json.encodeToJsonElement(this)
  *
  * Extension function on [String].
  *
- * @param verbose if `true`, logs a warning with the raw input on parse failure
+ * @param verbose if `true`, logs the full raw input string at WARN level on parse failure. Avoid this
+ *   for sensitive payloads, since the input may contain PII or secrets.
  * @return the parsed [JsonElement]
  * @throws kotlinx.serialization.SerializationException if parsing fails
  */

--- a/recaptcha-utils/src/main/kotlin/com/pambrose/common/recaptcha/RecaptchaService.kt
+++ b/recaptcha-utils/src/main/kotlin/com/pambrose/common/recaptcha/RecaptchaService.kt
@@ -163,7 +163,7 @@ object RecaptchaService : Closeable {
   }
 
   /**
-   * Adds the Google reCAPTCHA JavaScript to the HTML [HEAD] if reCAPTCHA is enabled and a site key is configured.
+   * Adds the Google reCAPTCHA JavaScript to the HTML [HEAD] if reCAPTCHA is enabled and both the site key and secret key are configured (kept in lockstep with server-side verification).
    *
    * This is an extension function on kotlinx.html [HEAD].
    *
@@ -180,7 +180,7 @@ object RecaptchaService : Closeable {
   }
 
   /**
-   * Renders the reCAPTCHA widget `<div>` in the HTML body if reCAPTCHA is enabled and a site key is configured.
+   * Renders the reCAPTCHA widget `<div>` in the HTML body if reCAPTCHA is enabled and both the site key and secret key are configured (kept in lockstep with server-side verification).
    *
    * This is an extension function on kotlinx.html [FlowContent].
    *

--- a/redis-utils/src/main/kotlin/com/pambrose/common/redis/RedisUtils.kt
+++ b/redis-utils/src/main/kotlin/com/pambrose/common/redis/RedisUtils.kt
@@ -121,14 +121,15 @@ object RedisUtils {
   /**
    * Creates a new pooled [RedisClient] with the given configuration.
    *
-   * Pool sizes default to values from system properties (see [REDIS_MAX_POOL_SIZE], etc.)
-   * or sensible defaults if those properties are not set.
+   * Each pool parameter defaults to its system property (see [REDIS_MAX_POOL_SIZE], etc.) if set,
+   * otherwise to the concrete fallback noted below. The connection and socket timeouts both use Jedis'
+   * `DEFAULT_TIMEOUT`.
    *
    * @param redisUrl the Redis connection URL (defaults to the `REDIS_URL` environment variable)
-   * @param maxPoolSize maximum number of connections in the pool
-   * @param maxIdleSize maximum number of idle connections
-   * @param minIdleSize minimum number of idle connections
-   * @param maxWaitSecs maximum seconds to wait when borrowing a connection
+   * @param maxPoolSize maximum connections in the pool; defaults to the [REDIS_MAX_POOL_SIZE] property or 10
+   * @param maxIdleSize maximum idle connections; defaults to the [REDIS_MAX_IDLE_SIZE] property or 5
+   * @param minIdleSize minimum idle connections; defaults to the [REDIS_MIN_IDLE_SIZE] property or 1
+   * @param maxWaitSecs seconds to wait when borrowing a connection; defaults to the [REDIS_MAX_WAIT_SECS] property or 1
    * @return a configured [RedisClient] with connection pooling
    */
   fun newRedisClient(

--- a/script-utils-common/src/main/kotlin/com/pambrose/common/script/AbstractExprEvaluator.kt
+++ b/script-utils-common/src/main/kotlin/com/pambrose/common/script/AbstractExprEvaluator.kt
@@ -22,6 +22,13 @@ import com.pambrose.common.script.ScriptUtils.resetContext
 abstract class AbstractExprEvaluator(
   extension: String,
 ) : AbstractEngine(extension) {
+  /**
+   * Evaluates [expr] and returns its [Boolean] result.
+   *
+   * @param expr the boolean expression to evaluate
+   * @return the boolean result of the evaluation
+   * @throws IllegalArgumentException if the expression does not evaluate to a [Boolean]
+   */
   fun eval(expr: String): Boolean {
     val result = engine.eval(expr)
     return result as? Boolean

--- a/script-utils-common/src/main/kotlin/com/pambrose/common/script/AbstractExprEvaluatorPool.kt
+++ b/script-utils-common/src/main/kotlin/com/pambrose/common/script/AbstractExprEvaluatorPool.kt
@@ -37,13 +37,22 @@ abstract class AbstractExprEvaluatorPool<T : AbstractExprEvaluator>(
 
   private suspend fun borrow() = channel.receive()
 
-  /** Returns `true` if there are no evaluator instances currently available in the pool. */
+  /**
+   * Returns an approximate, point-in-time indication of whether the pool currently has no evaluators
+   * available. Delegates to [Channel.isEmpty], which is racy under concurrent borrow/recycle and may
+   * return a stale result, so do not rely on it for correctness.
+   */
   val isEmpty get() = channel.isEmpty
 
   private suspend fun recycle(scriptObject: AbstractExprEvaluator) = channel.send(scriptObject)
 
   /**
-   * Evaluates the given expression by borrowing an evaluator from the pool, blocking the current thread.
+   * Evaluates [expr] by borrowing an evaluator from the pool, blocking the current thread until one is
+   * available and recycling it afterwards.
+   *
+   * The pool is a bounded buffer of [size] evaluators, so this blocks when all are in use and waits for
+   * one to be recycled. Do not call it more than [size] times concurrently, or from a context that
+   * already holds the pool's only evaluator, or it can deadlock.
    *
    * @param expr the expression to evaluate
    * @return the boolean result of the evaluation
@@ -53,6 +62,13 @@ abstract class AbstractExprEvaluatorPool<T : AbstractExprEvaluator>(
       eval(expr)
     }
 
+  /**
+   * Suspends until an evaluator can be borrowed from the pool, evaluates [expr], and recycles the
+   * evaluator afterwards. Suspends (rather than blocking) when all [size] evaluators are in use.
+   *
+   * @param expr the expression to evaluate
+   * @return the boolean result of the evaluation
+   */
   suspend fun eval(expr: String): Boolean =
     borrow()
       .let { engine ->

--- a/script-utils-common/src/main/kotlin/com/pambrose/common/script/AbstractScript.kt
+++ b/script-utils-common/src/main/kotlin/com/pambrose/common/script/AbstractScript.kt
@@ -72,6 +72,7 @@ abstract class AbstractScript(
    * @param name the variable name
    * @param types the type parameters; defaults to those previously registered for [name]
    * @return a formatted type parameter string, or an empty string if there are no parameters
+   * @throws IllegalStateException if [types] is omitted and no types were registered for [name]
    */
   open fun params(
     name: String,

--- a/script-utils-common/src/main/kotlin/com/pambrose/common/script/AbstractScriptPool.kt
+++ b/script-utils-common/src/main/kotlin/com/pambrose/common/script/AbstractScriptPool.kt
@@ -39,7 +39,11 @@ abstract class AbstractScriptPool<T : AbstractScript>(
 
   private suspend fun borrow() = channel.receive()
 
-  /** Returns `true` if there are no script instances currently available in the pool. */
+  /**
+   * Returns an approximate, point-in-time indication of whether the pool currently has no script
+   * instances available. Delegates to [Channel.isEmpty], which is racy under concurrent borrow/recycle
+   * and may return a stale result, so do not rely on it for correctness.
+   */
   val isEmpty get() = channel.isEmpty
 
   // Reset the context before returning to pool


### PR DESCRIPTION
KDoc corrections from the codebase review — making the public docs match actual behavior. **Docs only; no code/behavior change.** Dokka builds clean (all `[links]` resolve).

| Module | Fix |
|---|---|
| dropwizard-utils | `MetricsUtils` `@param size` → "at or above which" (unhealthy at `value == size`, matching the summary + boundary test) |
| recaptcha-utils | `loadRecaptchaScript`/`recaptchaWidget` now say **both** the site key **and secret key** must be configured (the real `isRecaptchaConfigured` gate) |
| exposed-utils | `toRowString` doc now describes joining each column's `toString()` omitting empty strings, and that a **null column renders as the literal `"null"`** (was the misleading "all non-empty column values") |
| json-utils | `toJsonElement(verbose)` warns it logs the **full raw input at WARN** — avoid for sensitive payloads (PII/secrets) |
| redis-utils | `newRedisClient` `@param`s now state each concrete default (10/5/1/1) and its system property |
| script-utils-common | `isEmpty` (pool × 2) noted as **approximate/racy** (`Channel.isEmpty`); `blockingEval` documents its **blocking/deadlock** contract; the previously-undocumented `eval()` on the pool and on `AbstractExprEvaluator` now have KDoc; `AbstractScript.params()` documents the `IllegalStateException` it throws |

The other 3 Documentation-category findings (Python "blocked" docs, `isValidEmail` limitations, the duplicated JavaScript note) were already handled in #123/#124.

`check` + Kotlinter + Detekt green across all 6 affected modules; `make kdocs` (Dokka) builds successfully.

> Note: #130 (idiomatic/perf, open) also touches `ExposedUtils`/`JsonElementUtils`/`RedisUtils`, but in **different functions** than these doc edits — they'll auto-merge; whichever lands second just needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)