### PR TITLE
Fix low-correctness issues in random(), sleepMillis(), and servlet headers

### DIFF
--- a/core-utils/src/main/java/com/pambrose/common/util/MiscJavaFuncs.java
+++ b/core-utils/src/main/java/com/pambrose/common/util/MiscJavaFuncs.java
@@ -22,11 +22,11 @@ public class MiscJavaFuncs {
   private static final Random random = new Random();
 
   public static int random(int upper) {
-    return Math.abs(random.nextInt() % upper);
+    return random.nextInt(upper);
   }
 
   public static long random(long upper) {
-    return Math.abs(random.nextLong() % upper);
+    return random.nextLong(upper);
   }
 
   public static void sleepSecs(long time) {
@@ -37,7 +37,10 @@ public class MiscJavaFuncs {
     try {
       Thread.sleep(time);
     } catch (InterruptedException e) {
-      e.printStackTrace();
+      // Thread.sleep clears the interrupt flag when it throws; restore it so callers can
+      // still detect the interruption. An interrupted sleep is a normal cancellation
+      // signal, not an error, so we do not log a stack trace.
+      Thread.currentThread().interrupt();
     }
   }
 }

--- a/core-utils/src/test/kotlin/com/pambrose/util/MiscJavaFuncsTests.kt
+++ b/core-utils/src/test/kotlin/com/pambrose/util/MiscJavaFuncsTests.kt
@@ -1,0 +1,91 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.pambrose.util
+
+import com.pambrose.common.util.MiscJavaFuncs
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class MiscJavaFuncsTests : StringSpec() {
+  init {
+    "random(int) returns a value in [0, upper) over many iterations" {
+      val upper = 100
+      repeat(100_000) {
+        val v = MiscJavaFuncs.random(upper)
+        (v in 0 until upper) shouldBe true
+      }
+    }
+
+    "random(long) returns a value in [0, upper) over many iterations" {
+      val upper = 100L
+      repeat(100_000) {
+        val v = MiscJavaFuncs.random(upper)
+        (v in 0L until upper) shouldBe true
+      }
+    }
+
+    "random(int) with an upper bound of 1 always returns 0" {
+      repeat(1_000) { MiscJavaFuncs.random(1) shouldBe 0 }
+    }
+
+    "random(long) with an upper bound of 1 always returns 0" {
+      repeat(1_000) { MiscJavaFuncs.random(1L) shouldBe 0L }
+    }
+
+    // Bounded RNG rejects non-positive bounds with IllegalArgumentException.
+    // Previously random(0) threw ArithmeticException ("/ by zero").
+    "random(int) rejects an upper bound of 0" {
+      shouldThrow<IllegalArgumentException> { MiscJavaFuncs.random(0) }
+    }
+
+    "random(long) rejects an upper bound of 0" {
+      shouldThrow<IllegalArgumentException> { MiscJavaFuncs.random(0L) }
+    }
+
+    // Previously a negative bound was silently accepted (returned a value in [0, |upper|)).
+    "random(int) rejects a negative upper bound" {
+      shouldThrow<IllegalArgumentException> { MiscJavaFuncs.random(-10) }
+    }
+
+    "random(long) rejects a negative upper bound" {
+      shouldThrow<IllegalArgumentException> { MiscJavaFuncs.random(-10L) }
+    }
+
+    // When Thread.sleep throws InterruptedException it clears the interrupt flag; sleepMillis
+    // must restore it so callers higher up can still observe the interruption.
+    "sleepMillis restores the thread interrupt flag when interrupted" {
+      Thread.interrupted() // clear any leaked flag first
+      // Setting the flag makes the subsequent Thread.sleep throw immediately and clear it.
+      Thread.currentThread().interrupt()
+
+      MiscJavaFuncs.sleepMillis(50)
+
+      // Thread.interrupted() reads-and-clears: asserts the flag was restored and cleans up
+      // so the state does not leak into other tests on this thread.
+      Thread.interrupted() shouldBe true
+    }
+
+    "sleepMillis leaves the interrupt flag clear on the normal path" {
+      Thread.interrupted() // defensive cleanup
+      MiscJavaFuncs.sleepMillis(1)
+      Thread.interrupted() shouldBe false
+    }
+  }
+}

--- a/grpc-utils/src/main/kotlin/com/pambrose/common/utils/ServerExtensions.kt
+++ b/grpc-utils/src/main/kotlin/com/pambrose/common/utils/ServerExtensions.kt
@@ -33,7 +33,9 @@ fun Server.shutdownWithJvm(maxWaitTime: Duration) {
       try {
         shutdownGracefully(maxWaitTime)
       } catch (e: InterruptedException) {
-        // do nothing
+        // Intentionally not restoring the interrupt flag: this runs in a JVM shutdown-hook
+        // thread that terminates as soon as this block returns, so there is no caller higher
+        // up that could observe a restored flag.
       }
     },
   )

--- a/ktor-server-utils/src/main/kotlin/com/pambrose/common/servlet/KtorServletResponse.kt
+++ b/ktor-server-utils/src/main/kotlin/com/pambrose/common/servlet/KtorServletResponse.kt
@@ -36,7 +36,10 @@ import java.util.*
  * @see servlet
  */
 class KtorServletResponse : HttpServletResponse {
-  private val headers = mutableMapOf<String, MutableList<String>>()
+  // HTTP header field names are case-insensitive (RFC 9110 §5.1). A TreeMap with the
+  // case-insensitive comparator matches header names regardless of casing while retaining
+  // the first-inserted casing for getHeaderNames().
+  private val headers = TreeMap<String, MutableList<String>>(String.CASE_INSENSITIVE_ORDER)
   private val buffer = ByteArrayOutputStream()
   private var statusCode: Int = HttpServletResponse.SC_OK
   private var contentTypeValue: String? = null

--- a/ktor-server-utils/src/test/kotlin/com/pambrose/common/servlet/KtorServletResponseTests.kt
+++ b/ktor-server-utils/src/test/kotlin/com/pambrose/common/servlet/KtorServletResponseTests.kt
@@ -49,6 +49,38 @@ class KtorServletResponseTests : StringSpec() {
       response.headerNames.toSet() shouldBe setOf("X-Custom")
     }
 
+    // HTTP header field names are case-insensitive (RFC 9110 §5.1); the HttpServletResponse
+    // contract treats them that way.
+    "header lookups are case-insensitive" {
+      val response = KtorServletResponse()
+      response.setHeader("X-Foo", "a")
+
+      response.containsHeader("x-foo") shouldBe true
+      response.containsHeader("X-FOO") shouldBe true
+      response.getHeader("x-foo") shouldBe "a"
+      response.getHeaders("X-fOo").toList() shouldBe listOf("a")
+    }
+
+    "setHeader with different casing overwrites rather than duplicating" {
+      val response = KtorServletResponse()
+      response.setHeader("X-Foo", "a")
+      response.setHeader("x-foo", "b")
+
+      response.getHeaders("X-Foo").toList() shouldBe listOf("b")
+      response.getHeader("x-FOO") shouldBe "b"
+      // A single logical header, retaining the first-inserted casing.
+      response.headerNames.toSet() shouldBe setOf("X-Foo")
+    }
+
+    "addHeader with different casing appends to the same header" {
+      val response = KtorServletResponse()
+      response.addHeader("Set-Cookie", "a")
+      response.addHeader("set-cookie", "b")
+
+      response.getHeaders("SET-COOKIE").toList() shouldBe listOf("a", "b")
+      response.headerNames.toSet() shouldBe setOf("Set-Cookie")
+    }
+
     "writer output captures content" {
       val response = KtorServletResponse()
       val writer = response.writer


### PR DESCRIPTION
Three low-priority correctness fixes from the codebase review. Each was independently verified against its authoritative contract, fixed test-first (RED→GREEN), and then adversarially reviewed (the skeptics could not refute any fix and confirmed each by reverting the change to prove the test catches the regression).

## Fixes

### 1. `MiscJavaFuncs.random(int)` / `random(long)` — modulo bias + input validation
Replaced `Math.abs(random.nextX() % upper)` with the bounded `random.nextInt(upper)` / `random.nextLong(upper)`.

- **Modulo bias (real):** `nextX() % upper` is non-uniform over `[0, upper)` whenever `upper` doesn't divide the generator's range evenly. The bounded methods are unbiased.
- **Input validation:** old code threw `ArithmeticException ("/ by zero")` for `upper == 0` and *silently accepted* a negative bound; the bounded methods reject `upper <= 0` with `IllegalArgumentException`.
- `nextLong(long)` is provided by `RandomGenerator`, available on the project's JVM 17 target.
- **False positive noted:** the review's *"can return a negative number"* claim is **not** true for this code — the `% upper` bounds the magnitude strictly below `upper`, so `Math.abs` can never overflow to a negative. Verified via the JLS remainder rules and empirically. The fix is justified on bias + validation grounds, not negativity.

### 2. `MiscJavaFuncs.sleepMillis` — interrupt-flag restoration
`Thread.sleep` clears the interrupt flag when it throws `InterruptedException`. The catch now restores it via `Thread.currentThread().interrupt()` so callers can still observe the interruption (cooperative cancellation). An interrupted sleep is a normal cancellation signal, not an error, so the previous `e.printStackTrace()` is dropped.

The `grpc-utils` `shutdownWithJvm` catch is **intentionally left** without flag restoration (now documented with a comment): it runs in a terminating JVM shutdown-hook thread where no higher caller could ever observe the flag, so restoring it has no effect.

### 3. `KtorServletResponse` — case-insensitive header names
HTTP header field names are case-insensitive (RFC 9110 §5.1) and the `HttpServletResponse` contract treats them that way, but the backing map was a case-sensitive `mutableMapOf`. Switched to `TreeMap(String.CASE_INSENSITIVE_ORDER)`:

- `setHeader("X-Foo", …)` is now visible via `getHeader("x-foo")` / `containsHeader("X-FOO")`.
- A mixed-case re-set **overwrites** the same header instead of emitting a duplicate differing only by case.
- First-inserted casing is retained for `getHeaderNames()`. No other method bodies needed changing.
- The only consumer (`ServletRoute.servlet`) iterates header *names* order-insensitively, and per-name value order is preserved by the backing list, so the insertion→sorted name-ordering change is HTTP-safe.

## Tests
- New `MiscJavaFuncsTests.kt` (the Java `MiscJavaFuncs` was previously untested): range contract, `upper == 1` degenerate boundary, `upper <= 0` rejection, and interrupt-flag restoration / normal-path cases.
- Three new `KtorServletResponseTests` cases for case-insensitive lookup, overwrite-on-different-casing, and `addHeader` append.

All affected modules (`core-utils`, `ktor-server-utils`, `grpc-utils`) pass `check` (tests + Kotlinter + Detekt + Kover). No in-repo callers of the changed `MiscJavaFuncs` functions exist, so there is no internal regression risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)