### PR TITLE
Add tests for open coverage gaps across six modules

### DIFF
--- a/email-utils/build.gradle.kts
+++ b/email-utils/build.gradle.kts
@@ -10,4 +10,6 @@ dependencies {
     api(libs.resend)
     api(libs.kotlinx.html)
     api(libs.ktor.http)
+
+    testImplementation(libs.mockk)
 }

--- a/email-utils/src/test/kotlin/com/pambrose/common/email/ResendServiceTests.kt
+++ b/email-utils/src/test/kotlin/com/pambrose/common/email/ResendServiceTests.kt
@@ -1,0 +1,125 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.pambrose.common.email
+
+import com.resend.Resend
+import com.resend.core.exception.ResendException
+import com.resend.services.emails.Emails
+import com.resend.services.emails.model.CreateEmailOptions
+import com.resend.services.emails.model.CreateEmailResponse
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.slot
+import io.mockk.unmockkAll
+
+/**
+ * Pins the request-mapping and exception-propagation contract of [ResendService.sendEmail]. The
+ * Resend SDK is intercepted via [mockkConstructor] (the `Resend` instance is constructed internally
+ * and is not injectable), so no real API key or network is involved.
+ */
+class ResendServiceTests : StringSpec() {
+  init {
+    // Tear down the constructor mock so it cannot leak into other specs.
+    afterTest { unmockkAll() }
+
+    "sendEmail maps from/to/cc/bcc/subject/html onto the Resend request as .value strings" {
+      mockkConstructor(Resend::class)
+      val emails = mockk<Emails>()
+      val captured = slot<CreateEmailOptions>()
+      every { anyConstructed<Resend>().emails() } returns emails
+      every { emails.send(capture(captured)) } returns CreateEmailResponse("id-123")
+
+      ResendService("test-api-key").sendEmail(
+        from = Email("Sender@Example.com"),
+        to = listOf(Email("a@example.com"), Email("b@example.com")),
+        cc = listOf(Email("cc@example.com")),
+        bcc = listOf(Email("bcc@example.com")),
+        subject = "Hello",
+        html = "<h1>Hi</h1>",
+      )
+
+      val req = captured.captured
+      req.from shouldBe "Sender@Example.com"
+      req.to shouldBe listOf("a@example.com", "b@example.com")
+      req.cc shouldBe listOf("cc@example.com")
+      req.bcc shouldBe listOf("bcc@example.com")
+      req.subject shouldBe "Hello"
+      req.html shouldBe "<h1>Hi</h1>"
+    }
+
+    "sendEmail builds a valid request with empty (defaulted) cc and bcc" {
+      mockkConstructor(Resend::class)
+      val emails = mockk<Emails>()
+      val captured = slot<CreateEmailOptions>()
+      every { anyConstructed<Resend>().emails() } returns emails
+      every { emails.send(capture(captured)) } returns CreateEmailResponse("id-456")
+
+      // cc and bcc omitted -> exercise the emptyList() defaults
+      ResendService("test-api-key").sendEmail(
+        from = Email("from@example.com"),
+        to = listOf(Email("only@example.com")),
+        subject = "Subj",
+        html = "<p>body</p>",
+      )
+
+      val req = captured.captured
+      req.to shouldBe listOf("only@example.com")
+      req.cc shouldBe emptyList()
+      req.bcc shouldBe emptyList()
+    }
+
+    "sendEmail returns normally on success" {
+      mockkConstructor(Resend::class)
+      val emails = mockk<Emails>()
+      every { anyConstructed<Resend>().emails() } returns emails
+      every { emails.send(any()) } returns CreateEmailResponse("ok-1")
+
+      // Should not throw.
+      ResendService("test-api-key").sendEmail(
+        from = Email("from@example.com"),
+        to = listOf(Email("to@example.com")),
+        subject = "Subj",
+        html = "<p>x</p>",
+      )
+    }
+
+    "sendEmail propagates (rethrows) the exception thrown by send()" {
+      mockkConstructor(Resend::class)
+      val emails = mockk<Emails>()
+      val boom = ResendException("send failed")
+      every { anyConstructed<Resend>().emails() } returns emails
+      every { emails.send(any()) } throws boom
+
+      val thrown =
+        shouldThrow<ResendException> {
+          ResendService("test-api-key").sendEmail(
+            from = Email("from@example.com"),
+            to = listOf(Email("to@example.com")),
+            subject = "Subj",
+            html = "<p>x</p>",
+          )
+        }
+      thrown.message shouldBe "send failed"
+    }
+  }
+}

--- a/jetty-utils/src/test/kotlin/com/pambrose/common/servlet/LambdaServletDoGetTests.kt
+++ b/jetty-utils/src/test/kotlin/com/pambrose/common/servlet/LambdaServletDoGetTests.kt
@@ -1,0 +1,106 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.pambrose.common.servlet
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import java.io.PrintWriter
+import java.io.StringWriter
+
+class LambdaServletDoGetTests : StringSpec() {
+  private fun createGetRequest(): HttpServletRequest =
+    mockk<HttpServletRequest> {
+      every { method } returns "GET"
+      every { protocol } returns "HTTP/1.1"
+      every { getHeader(any()) } returns null
+    }
+
+  init {
+    "lambda output is written to the response body" {
+      val response = mockk<HttpServletResponse>(relaxed = true)
+      val stringWriter = StringWriter()
+      every { response.writer } returns PrintWriter(stringWriter)
+
+      LambdaServlet { "Hello, World!" }.service(createGetRequest(), response)
+
+      stringWriter.toString().trim() shouldBe "Hello, World!"
+    }
+
+    "default constructor yields a text/plain content type" {
+      val response = mockk<HttpServletResponse>(relaxed = true)
+      every { response.writer } returns PrintWriter(StringWriter())
+
+      LambdaServlet { "body" }.service(createGetRequest(), response)
+
+      verify { response.contentType = "text/plain" }
+    }
+
+    "custom content type is honored" {
+      val response = mockk<HttpServletResponse>(relaxed = true)
+      val stringWriter = StringWriter()
+      every { response.writer } returns PrintWriter(stringWriter)
+
+      LambdaServlet("application/json") { """{"status":"ok"}""" }.service(createGetRequest(), response)
+
+      verify { response.contentType = "application/json" }
+      stringWriter.toString().trim() shouldBe """{"status":"ok"}"""
+    }
+
+    "status is set to SC_OK" {
+      val response = mockk<HttpServletResponse>(relaxed = true)
+      every { response.writer } returns PrintWriter(StringWriter())
+
+      LambdaServlet { "body" }.service(createGetRequest(), response)
+
+      verify { response.status = HttpServletResponse.SC_OK }
+    }
+
+    "cache-control header is set to the no-cache literal" {
+      val response = mockk<HttpServletResponse>(relaxed = true)
+      every { response.writer } returns PrintWriter(StringWriter())
+
+      LambdaServlet { "body" }.service(createGetRequest(), response)
+
+      verify { response.setHeader("Cache-Control", "must-revalidate,no-cache,no-store") }
+    }
+
+    "the lambda is evaluated on every request" {
+      var counter = 0
+      val servlet = LambdaServlet { "count=${++counter}" }
+
+      val firstWriter = StringWriter()
+      val firstResponse = mockk<HttpServletResponse>(relaxed = true)
+      every { firstResponse.writer } returns PrintWriter(firstWriter)
+      servlet.service(createGetRequest(), firstResponse)
+
+      val secondWriter = StringWriter()
+      val secondResponse = mockk<HttpServletResponse>(relaxed = true)
+      every { secondResponse.writer } returns PrintWriter(secondWriter)
+      servlet.service(createGetRequest(), secondResponse)
+
+      firstWriter.toString().trim() shouldBe "count=1"
+      secondWriter.toString().trim() shouldBe "count=2"
+    }
+  }
+}

--- a/recaptcha-utils/build.gradle.kts
+++ b/recaptcha-utils/build.gradle.kts
@@ -10,4 +10,6 @@ dependencies {
     implementation(libs.bundles.ktor.client.json)
     api(libs.ktor.server.core)
     api(libs.kotlinx.html)
+
+    testImplementation(libs.ktor.server.test.host)
 }

--- a/recaptcha-utils/src/test/kotlin/com/pambrose/common/recaptcha/RecaptchaServiceTests.kt
+++ b/recaptcha-utils/src/test/kotlin/com/pambrose/common/recaptcha/RecaptchaServiceTests.kt
@@ -1,0 +1,147 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.pambrose.common.recaptcha
+
+import com.pambrose.common.recaptcha.RecaptchaService.loadRecaptchaScript
+import com.pambrose.common.recaptcha.RecaptchaService.validateRecaptcha
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import kotlinx.html.head
+import kotlinx.html.stream.createHTML
+
+/**
+ * Covers the previously-untested routing logic of [RecaptchaService.validateRecaptcha] and the
+ * HEAD script injection. Only the network-free branches are exercised: the disabled-gate
+ * short-circuit and the missing/blank-token 400 path. The success/failure branches flow through a
+ * private, hardcoded CIO [io.ktor.client.HttpClient] against the real Google siteverify URL and are
+ * not testable without a production injection seam.
+ */
+class RecaptchaServiceTests : StringSpec() {
+  init {
+    fun config(
+      enabled: Boolean,
+      siteKey: String?,
+      secretKey: String?,
+    ) = object : RecaptchaConfig {
+      override val isRecaptchaEnabled = enabled
+      override val recaptchaSiteKey = siteKey
+      override val recaptchaSecretKey = secretKey
+    }
+
+    "validateRecaptcha passes through without network when reCAPTCHA is not configured" {
+      testApplication {
+        routing {
+          post("/v") {
+            val ok =
+              with(RecaptchaService) {
+                validateRecaptcha(config(enabled = false, siteKey = null, secretKey = null), call.receiveParameters())
+              }
+            call.respondText(if (ok) "passed" else "blocked")
+          }
+        }
+        // No g-recaptcha-response sent, but the disabled gate short-circuits to true.
+        client.post("/v") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody("")
+        }.apply {
+          status shouldBe HttpStatusCode.OK
+          bodyAsText() shouldBe "passed"
+        }
+      }
+    }
+
+    "validateRecaptcha responds 400 when configured and the token is missing" {
+      testApplication {
+        routing {
+          post("/v") {
+            val ok =
+              with(RecaptchaService) {
+                validateRecaptcha(
+                  config(enabled = true, siteKey = "site", secretKey = "secret"),
+                  call.receiveParameters(),
+                )
+              }
+            // When ok is false the extension has already written the 400 body; do not write again.
+            if (ok) call.respondText("passed")
+          }
+        }
+        client.post("/v") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody("")
+        }.apply {
+          status shouldBe HttpStatusCode.BadRequest
+          bodyAsText() shouldContain "reCAPTCHA verification required"
+        }
+      }
+    }
+
+    "validateRecaptcha responds 400 when configured and the token is blank" {
+      testApplication {
+        routing {
+          post("/v") {
+            val ok =
+              with(RecaptchaService) {
+                validateRecaptcha(
+                  config(enabled = true, siteKey = "site", secretKey = "secret"),
+                  call.receiveParameters(),
+                )
+              }
+            if (ok) call.respondText("passed")
+          }
+        }
+        client.post("/v") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody("g-recaptcha-response=")
+        }.apply {
+          status shouldBe HttpStatusCode.BadRequest
+          bodyAsText() shouldContain "reCAPTCHA verification required"
+        }
+      }
+    }
+
+    fun renderHead(config: RecaptchaConfig): String =
+      with(RecaptchaService) {
+        createHTML().head { loadRecaptchaScript(config) }
+      }
+
+    "loadRecaptchaScript emits the api.js script when fully configured" {
+      renderHead(config(enabled = true, siteKey = "site", secretKey = "secret")) shouldContain
+        "https://www.google.com/recaptcha/api.js"
+    }
+
+    "loadRecaptchaScript emits nothing when disabled or a key is missing" {
+      renderHead(config(enabled = false, siteKey = "site", secretKey = "secret")) shouldNotContain "api.js"
+      renderHead(config(enabled = true, siteKey = null, secretKey = "secret")) shouldNotContain "api.js"
+      renderHead(config(enabled = true, siteKey = "site", secretKey = null)) shouldNotContain "api.js"
+    }
+  }
+}

--- a/redis-utils/src/test/kotlin/com/pambrose/common/redis/RedisUtilsTests.kt
+++ b/redis-utils/src/test/kotlin/com/pambrose/common/redis/RedisUtilsTests.kt
@@ -22,6 +22,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import java.net.URI
 
 class RedisUtilsTests : StringSpec() {
   init {
@@ -86,6 +87,35 @@ class RedisUtilsTests : StringSpec() {
       )
       client shouldNotBe null
       client.close()
+    }
+
+    // RedisInfo.includeUserInAuth decides whether to send the username in AUTH: only when the
+    // user is a real (non-placeholder) name and the password is not the "none" placeholder.
+    "includeUserInAuth is true for a real user with a real password" {
+      RedisUtils.RedisInfo(URI("redis://h"), "alice", "secret").includeUserInAuth shouldBe true
+    }
+
+    "includeUserInAuth is false for the 'default' placeholder user" {
+      RedisUtils.RedisInfo(URI("redis://h"), "default", "secret").includeUserInAuth shouldBe false
+    }
+
+    "includeUserInAuth is false for the 'user' placeholder user" {
+      RedisUtils.RedisInfo(URI("redis://h"), "user", "secret").includeUserInAuth shouldBe false
+    }
+
+    "includeUserInAuth is false when the password is the 'none' placeholder" {
+      RedisUtils.RedisInfo(URI("redis://h"), "alice", "none").includeUserInAuth shouldBe false
+    }
+
+    "includeUserInAuth is false when the user is blank" {
+      RedisUtils.RedisInfo(URI("redis://h"), "", "secret").includeUserInAuth shouldBe false
+    }
+
+    "RedisInfo exposes the parsed uri, user, and password" {
+      val info = RedisUtils.RedisInfo(URI("redis://h:6379"), "alice", "secret")
+      info.user shouldBe "alice"
+      info.password shouldBe "secret"
+      info.uri.host shouldBe "h"
     }
   }
 }

--- a/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/AbstractScriptAddMessageTests.kt
+++ b/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/AbstractScriptAddMessageTests.kt
@@ -1,0 +1,94 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.pambrose.common.script
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import javax.script.ScriptException
+import kotlin.reflect.typeOf
+
+/**
+ * Characterization tests pinning the exact ScriptException / IllegalStateException messages produced
+ * by [AbstractScript.add] and [AbstractScript.params], exercised through the concrete [KotlinScript].
+ * The existing KotlinScriptTests / JavaScriptTests already prove each branch THROWS; these lock the
+ * message text and singular/plural wording so a regression in message content or branch routing is
+ * caught.
+ */
+class AbstractScriptAddMessageTests : StringSpec() {
+  init {
+    "add rejects a local class with a local/anonymous-class message" {
+      class Local // local class -> qualifiedName is null
+
+      KotlinScript().use { script ->
+        val e = shouldThrow<ScriptException> { script.add("x", Local()) }
+        e.message shouldContain "is a local or an anonymous class"
+        e.message shouldContain "\"x\"" // qname is the name double-quoted
+      }
+    }
+
+    "add reports missing type parameters with singular wording" {
+      KotlinScript().use { script ->
+        val e = shouldThrow<ScriptException> { script.add("list", mutableListOf(1)) }
+        // pluralize(1) keeps the singular "parameter"
+        e.message shouldContain "Expected 1 type parameter to be specified for"
+        e.message shouldContain "\"list\""
+      }
+    }
+
+    "add reports an unexpected single type parameter with the formatted type and singular wording" {
+      KotlinScript().use { script ->
+        val e = shouldThrow<ScriptException> { script.add("value", 5, typeOf<Int>()) }
+        // params() strips the "kotlin." prefix -> <Int>; one type -> "parameter"
+        e.message shouldContain "Invalid type parameter <Int> specified for"
+        e.message shouldContain "\"value\""
+      }
+    }
+
+    "add reports unexpected multiple type parameters with plural wording" {
+      KotlinScript().use { script ->
+        val e = shouldThrow<ScriptException> { script.add("value", 5, typeOf<Int>(), typeOf<String>()) }
+        // two types -> "parameters"; both prefixes stripped
+        e.message shouldContain "Invalid type parameters <Int, String> specified for"
+      }
+    }
+
+    "add reports a type-count mismatch with the expected and found counts" {
+      KotlinScript().use { script ->
+        val e =
+          shouldThrow<ScriptException> {
+            script.add("list", mutableListOf(1), typeOf<Int?>(), typeOf<Int>()) // 2 types vs 1 expected
+          }
+        // paramCnt == 1 drives the singular "parameter"; the found count and the rendered type list
+        // ("kotlin." stripped) are both pinned.
+        e.message shouldContain "Expected 1 type parameter for"
+        e.message shouldContain "\"list\""
+        e.message shouldContain "but found 2: <Int?, Int>"
+      }
+    }
+
+    "params raises an IllegalStateException when no types are registered for the name" {
+      KotlinScript().use { script ->
+        val e = shouldThrow<IllegalStateException> { script.params("never") }
+        e.message shouldBe "No type parameters registered for never"
+      }
+    }
+  }
+}

--- a/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/ScriptPoolContractTests.kt
+++ b/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/ScriptPoolContractTests.kt
@@ -1,0 +1,139 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.pambrose.common.script
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import javax.script.ScriptException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Characterization tests for the borrow/recycle and context-reset contracts of [AbstractScriptPool]
+ * and [AbstractExprEvaluatorPool], exercised through the concrete [KotlinScriptPool] /
+ * [KotlinExprEvaluatorPool]. A pool size of 1 is used deliberately: any failure to recycle (on
+ * success OR on exception) drains the pool, which a subsequent borrow would expose.
+ *
+ * Each body is wrapped in [withTimeout] so that a recycle regression (which would otherwise suspend
+ * the next `channel.receive()` forever) fails fast as a [kotlinx.coroutines.TimeoutCancellationException]
+ * instead of hanging until the CI wall-clock kills the job.
+ */
+class ScriptPoolContractTests : StringSpec() {
+  init {
+    "script pool of size 1 can be reused repeatedly (recycle on success)" {
+      runBlocking {
+        withTimeout(TIMEOUT_MS) {
+          val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
+          repeat(5) { i ->
+            pool.eval { eval("$i + 1") } shouldBe i + 1
+          }
+        }
+      }
+    }
+
+    "script pool recycles the instance and resets context when the eval block throws" {
+      runBlocking {
+        withTimeout(TIMEOUT_MS) {
+          val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
+
+          shouldThrow<RuntimeException> {
+            pool.eval {
+              add("leak", 1) // mutate the context before throwing, to test reset on the exception path
+              throw RuntimeException("boom")
+            }
+          }
+
+          // The single instance was returned (else the next borrow would hang)...
+          pool.isEmpty shouldBe false
+          // ...and resetContext ran on recycle even though the block threw, so "leak" is unbound.
+          shouldThrow<ScriptException> { pool.eval { eval("leak") } }
+          pool.eval { eval("40 + 2") } shouldBe 42
+        }
+      }
+    }
+
+    "script pool resets context between borrows (a var added in one eval is gone in the next)" {
+      runBlocking {
+        withTimeout(TIMEOUT_MS) {
+          val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
+
+          pool.eval {
+            add("x", 99)
+            eval("x")
+          } shouldBe 99
+
+          shouldThrow<ScriptException> {
+            pool.eval { eval("x") }
+          }
+        }
+      }
+    }
+
+    "script pool isEmpty is true while borrowed and false after recycle" {
+      runBlocking {
+        withTimeout(TIMEOUT_MS) {
+          val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
+          pool.isEmpty shouldBe false
+
+          pool.eval {
+            pool.isEmpty shouldBe true // the sole instance is borrowed for the duration of the block
+            eval("1 + 1")
+          } shouldBe 2
+
+          pool.isEmpty shouldBe false
+        }
+      }
+    }
+
+    "expr pool of size 1 can be reused repeatedly (recycle on success)" {
+      runBlocking {
+        withTimeout(TIMEOUT_MS) {
+          val pool = KotlinExprEvaluatorPool(size = 1)
+          repeat(5) {
+            pool.eval("1 > 0") shouldBe true
+          }
+        }
+      }
+    }
+
+    "expr pool still recycles the evaluator when eval throws" {
+      runBlocking {
+        withTimeout(TIMEOUT_MS) {
+          val pool = KotlinExprEvaluatorPool(size = 1)
+
+          // A non-boolean result -> AbstractExprEvaluator.eval throws IllegalArgumentException.
+          shouldThrow<IllegalArgumentException> {
+            pool.eval("1 + 2")
+          }
+
+          // The evaluator was recycled despite the throw; the pool is not drained.
+          pool.isEmpty shouldBe false
+          pool.eval("1 > 0") shouldBe true
+        }
+      }
+    }
+  }
+
+  companion object {
+    // Generous enough for the JSR-223 engine init/compile, but bounded so a broken recycle fails
+    // fast instead of hanging.
+    private const val TIMEOUT_MS = 30_000L
+  }
+}


### PR DESCRIPTION
Fills the open **Test Coverage Gap** findings from the codebase review. This PR is **test-only** — no production code is changed — plus two test-scoped dependency additions (`mockk` for email-utils, `ktor-server-test-host` for recaptcha-utils).

Each gap was first checked against existing coverage, so the new cases are the genuinely-missing ones, not duplicates. **33 new test cases** across six modules.

## What's covered

| Module | Test | Gap filled |
|--------|------|------------|
| script-utils-kotlin | `AbstractScriptAddMessageTests` | The `add()` branches already *throw*-tested in the subclass suites; these pin the exact `ScriptException` message text + singular/plural wording, plus the untested `params()` `IllegalStateException` path. |
| recaptcha-utils | `RecaptchaServiceTests` | `validateRecaptcha`'s network-free branches (disabled-gate short-circuit, missing/blank-token 400) via `testApplication`, plus `loadRecaptchaScript`. |
| jetty-utils | `LambdaServletDoGetTests` | `doGet` status, content type, `Cache-Control` header, body, and per-request lambda evaluation (the existing test only checked construction). |
| email-utils | `ResendServiceTests` | `sendEmail` request mapping (`from`/`to`/`cc`/`bcc` → `.value`) and exception propagation, intercepting the internal Resend SDK via `mockkConstructor`. |
| script-utils-kotlin | `ScriptPoolContractTests` | Size-1 pools prove recycle-on-success, recycle + context-reset on exception, and context reset between borrows; `withTimeout` makes a recycle regression fail fast instead of hanging. |
| redis-utils | `RedisUtilsTests` (+6 cases) | `RedisInfo.includeUserInAuth` across the user/password placeholder combinations (each conjunct independently guarded). |

## Process
Each test was planned by a workflow that read the existing tests first, authored and run green, then adversarially quality-reviewed — all confirmed **genuine guards with no tautological assertions** (one reviewer empirically verified a `pluralize` mutation makes the message test go red). Two reviewer-suggested strengthenings were applied: pinning the full `<Int?, Int>` type list in the `add` message test, and adding fail-fast `withTimeout` + reset-on-exception verification to the pool tests.

## Known limitations (uncovered by design)
- `RedisUtils.urlDetails` (private) URL parsing isn't reachable from tests — `RedisInfo.includeUserInAuth` is covered instead.
- `RecaptchaService.verifyRecaptcha` uses a hardcoded CIO `HttpClient` against the real Google endpoint; its success/failure path isn't unit-testable without a production injection seam.

All five affected modules pass `check` (tests + Kotlinter + Detekt + Kover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)