### PR TITLE
Return Any? from JavaScript.eval/evalScript to allow null results

### DIFF
--- a/script-utils-java/src/main/kotlin/com/pambrose/common/script/JavaScript.kt
+++ b/script-utils-java/src/main/kotlin/com/pambrose/common/script/JavaScript.kt
@@ -113,13 +113,13 @@ class JavaScript :
    *
    * @param script the Java source code to evaluate
    * @param verbose if `true`, logs the generated script before evaluation
-   * @return the result of the script evaluation
+   * @return the result of the script evaluation, or `null` if the script evaluates to `null`
    */
   @Synchronized
   fun evalScript(
     script: String,
     verbose: Boolean = false,
-  ): Any {
+  ): Any? {
     ScriptGuards.checkNoJvmExit(script)
 
     if (!initialized) {
@@ -135,12 +135,23 @@ class JavaScript :
     return engine.eval(code)
   }
 
+  /**
+   * Evaluates a Java [expr] (optionally preceded by an [action] statement block) inside a generated
+   * `Main.getValue()` method, prepending any registered imports and variable declarations.
+   *
+   * On the first call, registered variable bindings are placed into the engine context.
+   *
+   * @param expr the Java expression whose value is returned
+   * @param action optional Java statements executed before [expr] is evaluated
+   * @param verbose if `true`, logs the generated script before evaluation
+   * @return the result of evaluating [expr], or `null` if it evaluates to `null`
+   */
   @Synchronized
   fun eval(
     expr: String,
     action: String = "",
     verbose: Boolean = false,
-  ): Any {
+  ): Any? {
     ScriptGuards.checkNoJvmExit(expr, action)
 
     val code = """

--- a/script-utils-java/src/test/kotlin/com/pambrose/common/script/JavaScriptNullResultTests.kt
+++ b/script-utils-java/src/test/kotlin/com/pambrose/common/script/JavaScriptNullResultTests.kt
@@ -1,0 +1,48 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.pambrose.common.script
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class JavaScriptNullResultTests : StringSpec() {
+  init {
+    "eval returns null when the expression evaluates to null" {
+      JavaScript().use { it.eval("null") shouldBe null }
+    }
+
+    "eval returns null when the action produces a null result" {
+      JavaScript().use { it.eval("s", "String s = null;") shouldBe null }
+    }
+
+    "evalScript returns null when the callable method returns null" {
+      JavaScript().use {
+        it.evalScript(
+          """
+          public class Main {
+            public Object getValue() {
+              return null;
+            }
+          }
+          """.trimIndent(),
+        ) shouldBe null
+      }
+    }
+  }
+}


### PR DESCRIPTION
## The bug (runtime NPE)

`JavaScript.eval(...)` and `JavaScript.evalScript(...)` declared a non-null `Any` return type, but both `return engine.eval(code)` — a platform-typed `javax.script.ScriptEngine.eval` call that can legitimately return `null` (e.g. a Java expression evaluating to `null`). The non-null declaration made the Kotlin compiler insert a return-value null-check, so:

```kotlin
JavaScript().use { it.eval("null") }   // threw NullPointerException: eval(...) must not be null
```

instead of returning `null`.

## The fix

Widen both return types from `Any` to `Any?` so a null result is returned honestly. This also **aligns JavaScript with its siblings** — `KotlinScript.eval` and `PythonScript.eval` already return `Any?` (JavaScript was the lone outlier).

## Verification

Driven test-first (RED→GREEN) and verified by an adversarial workflow (both verdicts `ship-as-is`, high confidence):
- **Regression tests** (`JavaScriptNullResultTests`) cover `eval("null")`, `eval` with a null-producing action, and `evalScript` returning null — all threw the NPE before the fix, pass after.
- **Completeness**: every method in the `JavaScript`/`AbstractScript`/`AbstractEngine` hierarchy was audited — `eval`/`evalScript` were the *only* two affected (the rest return locally-built non-null strings).
- **No behavior change for non-null results**: the full suite stays green; both `Any` and `Any?` erase to `Object`, so the only bytecode difference is the removed null-check.

## Compatibility note

- **Binary-compatible**: both types erase to `java.lang.Object`; existing compiled callers link fine and pure-Java callers are unaffected.
- **Source-breaking only** for Kotlin callers binding the result to a non-null type (`val x: Any = js.eval(...)`) — i.e. exactly the call sites that previously crashed with the NPE. This converts a latent runtime NPE into a compile-time signal. **No in-repo callers are affected.**
- Since this is published to Maven Central, the `Any → Any?` widening is worth a (benign, recompile-only) source-compat line in the release notes.

Also gives `eval()` a KDoc block matching `evalScript()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)