### PR TITLE
Drop redundant runBlocking wrappers in suspend test bodies

### DIFF
--- a/redis-utils/src/test/kotlin/com/pambrose/common/redis/BugFixVerificationTests.kt
+++ b/redis-utils/src/test/kotlin/com/pambrose/common/redis/BugFixVerificationTests.kt
@@ -32,7 +32,6 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import java.util.concurrent.atomic.AtomicInteger
-import kotlinx.coroutines.runBlocking
 import redis.clients.jedis.exceptions.JedisConnectionException
 
 class BugFixVerificationTests : StringSpec() {
@@ -112,39 +111,35 @@ class BugFixVerificationTests : StringSpec() {
     }
 
     "withSuspendingRedisPool: connection failure invokes block exactly once with null" {
-      runBlocking {
-        val callCount = AtomicInteger(0)
-        val client = RedisUtils.newRedisClient(redisUrl = unreachableUrl, maxPoolSize = 1)
-        try {
-          val result =
-            client.withSuspendingRedisPool { c ->
-              callCount.incrementAndGet()
-              c shouldBe null
-              "from-null-branch"
-            }
-          result shouldBe "from-null-branch"
-          callCount.get() shouldBe 1
-        } finally {
-          client.close()
-        }
+      val callCount = AtomicInteger(0)
+      val client = RedisUtils.newRedisClient(redisUrl = unreachableUrl, maxPoolSize = 1)
+      try {
+        val result =
+          client.withSuspendingRedisPool { c ->
+            callCount.incrementAndGet()
+            c shouldBe null
+            "from-null-branch"
+          }
+        result shouldBe "from-null-branch"
+        callCount.get() shouldBe 1
+      } finally {
+        client.close()
       }
     }
 
     "withSuspendingNonNullRedisPool: connection failure returns null without invoking block" {
-      runBlocking {
-        val callCount = AtomicInteger(0)
-        val client = RedisUtils.newRedisClient(redisUrl = unreachableUrl, maxPoolSize = 1)
-        try {
-          val result =
-            client.withSuspendingNonNullRedisPool { _ ->
-              callCount.incrementAndGet()
-              "should-not-reach"
-            }
-          result shouldBe null
-          callCount.get() shouldBe 0
-        } finally {
-          client.close()
-        }
+      val callCount = AtomicInteger(0)
+      val client = RedisUtils.newRedisClient(redisUrl = unreachableUrl, maxPoolSize = 1)
+      try {
+        val result =
+          client.withSuspendingNonNullRedisPool { _ ->
+            callCount.incrementAndGet()
+            "should-not-reach"
+          }
+        result shouldBe null
+        callCount.get() shouldBe 0
+      } finally {
+        client.close()
       }
     }
 
@@ -187,16 +182,14 @@ class BugFixVerificationTests : StringSpec() {
     }
 
     "withSuspendingRedis: block JedisConnectionException propagates and block invoked once" {
-      runBlocking {
-        val callCount = AtomicInteger(0)
-        shouldThrow<JedisConnectionException> {
-          withSuspendingRedis(redisUrl = unreachableUrl) { _ ->
-            callCount.incrementAndGet()
-            throw JedisConnectionException("simulated mid-block failure")
-          }
+      val callCount = AtomicInteger(0)
+      shouldThrow<JedisConnectionException> {
+        withSuspendingRedis(redisUrl = unreachableUrl) { _ ->
+          callCount.incrementAndGet()
+          throw JedisConnectionException("simulated mid-block failure")
         }
-        callCount.get() shouldBe 1
       }
+      callCount.get() shouldBe 1
     }
   }
 }

--- a/script-utils-java/src/test/kotlin/com/pambrose/common/script/JavaScriptTests.kt
+++ b/script-utils-java/src/test/kotlin/com/pambrose/common/script/JavaScriptTests.kt
@@ -20,7 +20,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import kotlinx.coroutines.runBlocking
 import javax.script.ScriptContext.GLOBAL_SCOPE
 import javax.script.ScriptException
 import kotlin.reflect.typeOf
@@ -240,11 +239,9 @@ class JavaScriptTests : StringSpec() {
     // the initial population and after recycling, even when the pool is created with true.
     "pool keeps non-null global context regardless of nullGlobalContext" {
       val pool = JavaScriptPool(2, nullGlobalContext = true)
-      runBlocking {
-        // Three evals on a pool of size two force a recycle between borrows.
-        repeat(3) {
-          pool.eval { engine.getBindings(GLOBAL_SCOPE) } shouldNotBe null
-        }
+      // Three evals on a pool of size two force a recycle between borrows.
+      repeat(3) {
+        pool.eval { engine.getBindings(GLOBAL_SCOPE) } shouldNotBe null
       }
     }
   }

--- a/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/BugFixVerificationTests.kt
+++ b/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/BugFixVerificationTests.kt
@@ -23,7 +23,6 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
-import kotlinx.coroutines.runBlocking
 import javax.script.ScriptContext.GLOBAL_SCOPE
 import javax.script.ScriptException
 
@@ -130,15 +129,13 @@ class BugFixVerificationTests : StringSpec() {
     // on the first borrow. After fix: the initial instances honor the flag.
 
     "pool honors nullGlobalContext for initial population" {
-      runBlocking {
-        KotlinScriptPool(2, nullGlobalContext = true).eval {
-          engine.getBindings(GLOBAL_SCOPE)
-        } shouldBe null
+      KotlinScriptPool(2, nullGlobalContext = true).eval {
+        engine.getBindings(GLOBAL_SCOPE)
+      } shouldBe null
 
-        KotlinScriptPool(2, nullGlobalContext = false).eval {
-          engine.getBindings(GLOBAL_SCOPE)
-        } shouldNotBe null
-      }
+      KotlinScriptPool(2, nullGlobalContext = false).eval {
+        engine.getBindings(GLOBAL_SCOPE)
+      } shouldNotBe null
     }
   }
 }

--- a/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/ScriptPoolContractTests.kt
+++ b/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/ScriptPoolContractTests.kt
@@ -22,7 +22,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import javax.script.ScriptException
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
 /**
@@ -31,102 +30,91 @@ import kotlinx.coroutines.withTimeout
  * [KotlinExprEvaluatorPool]. A pool size of 1 is used deliberately: any failure to recycle (on
  * success OR on exception) drains the pool, which a subsequent borrow would expose.
  *
- * Each body is wrapped in [withTimeout] so that a recycle regression (which would otherwise suspend
- * the next `channel.receive()` forever) fails fast as a [kotlinx.coroutines.TimeoutCancellationException]
+ * Kotest test bodies are already suspending, so the pool's `suspend` APIs are called directly. Each
+ * body is wrapped in [withTimeout] so that a recycle regression (which would otherwise suspend the
+ * next `channel.receive()` forever) fails fast as a [kotlinx.coroutines.TimeoutCancellationException]
  * instead of hanging until the CI wall-clock kills the job.
  */
 class ScriptPoolContractTests : StringSpec() {
   init {
     "script pool of size 1 can be reused repeatedly (recycle on success)" {
-      runBlocking {
-        withTimeout(TIMEOUT_MS) {
-          val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
-          repeat(5) { i ->
-            pool.eval { eval("$i + 1") } shouldBe i + 1
-          }
+      withTimeout(TIMEOUT_MS) {
+        val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
+        repeat(5) { i ->
+          pool.eval { eval("$i + 1") } shouldBe i + 1
         }
       }
     }
 
     "script pool recycles the instance and resets context when the eval block throws" {
-      runBlocking {
-        withTimeout(TIMEOUT_MS) {
-          val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
+      withTimeout(TIMEOUT_MS) {
+        val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
 
-          shouldThrow<RuntimeException> {
-            pool.eval {
-              add("leak", 1) // mutate the context before throwing, to test reset on the exception path
-              throw RuntimeException("boom")
-            }
+        shouldThrow<RuntimeException> {
+          pool.eval {
+            add("leak", 1) // mutate the context before throwing, to test reset on the exception path
+            throw RuntimeException("boom")
           }
-
-          // The single instance was returned (else the next borrow would hang)...
-          pool.isEmpty shouldBe false
-          // ...and resetContext ran on recycle even though the block threw, so "leak" is unbound.
-          shouldThrow<ScriptException> { pool.eval { eval("leak") } }
-          pool.eval { eval("40 + 2") } shouldBe 42
         }
+
+        // The single instance was returned (else the next borrow would hang)...
+        pool.isEmpty shouldBe false
+        // ...and resetContext ran on recycle even though the block threw, so "leak" is unbound.
+        shouldThrow<ScriptException> { pool.eval { eval("leak") } }
+        pool.eval { eval("40 + 2") } shouldBe 42
       }
     }
 
     "script pool resets context between borrows (a var added in one eval is gone in the next)" {
-      runBlocking {
-        withTimeout(TIMEOUT_MS) {
-          val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
+      withTimeout(TIMEOUT_MS) {
+        val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
 
-          pool.eval {
-            add("x", 99)
-            eval("x")
-          } shouldBe 99
+        pool.eval {
+          add("x", 99)
+          eval("x")
+        } shouldBe 99
 
-          shouldThrow<ScriptException> {
-            pool.eval { eval("x") }
-          }
+        shouldThrow<ScriptException> {
+          pool.eval { eval("x") }
         }
       }
     }
 
     "script pool isEmpty is true while borrowed and false after recycle" {
-      runBlocking {
-        withTimeout(TIMEOUT_MS) {
-          val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
-          pool.isEmpty shouldBe false
+      withTimeout(TIMEOUT_MS) {
+        val pool = KotlinScriptPool(size = 1, nullGlobalContext = false)
+        pool.isEmpty shouldBe false
 
-          pool.eval {
-            pool.isEmpty shouldBe true // the sole instance is borrowed for the duration of the block
-            eval("1 + 1")
-          } shouldBe 2
+        pool.eval {
+          pool.isEmpty shouldBe true // the sole instance is borrowed for the duration of the block
+          eval("1 + 1")
+        } shouldBe 2
 
-          pool.isEmpty shouldBe false
-        }
+        pool.isEmpty shouldBe false
       }
     }
 
     "expr pool of size 1 can be reused repeatedly (recycle on success)" {
-      runBlocking {
-        withTimeout(TIMEOUT_MS) {
-          val pool = KotlinExprEvaluatorPool(size = 1)
-          repeat(5) {
-            pool.eval("1 > 0") shouldBe true
-          }
+      withTimeout(TIMEOUT_MS) {
+        val pool = KotlinExprEvaluatorPool(size = 1)
+        repeat(5) {
+          pool.eval("1 > 0") shouldBe true
         }
       }
     }
 
     "expr pool still recycles the evaluator when eval throws" {
-      runBlocking {
-        withTimeout(TIMEOUT_MS) {
-          val pool = KotlinExprEvaluatorPool(size = 1)
+      withTimeout(TIMEOUT_MS) {
+        val pool = KotlinExprEvaluatorPool(size = 1)
 
-          // A non-boolean result -> AbstractExprEvaluator.eval throws IllegalArgumentException.
-          shouldThrow<IllegalArgumentException> {
-            pool.eval("1 + 2")
-          }
-
-          // The evaluator was recycled despite the throw; the pool is not drained.
-          pool.isEmpty shouldBe false
-          pool.eval("1 > 0") shouldBe true
+        // A non-boolean result -> AbstractExprEvaluator.eval throws IllegalArgumentException.
+        shouldThrow<IllegalArgumentException> {
+          pool.eval("1 + 2")
         }
+
+        // The evaluator was recycled despite the throw; the pool is not drained.
+        pool.isEmpty shouldBe false
+        pool.eval("1 > 0") shouldBe true
       }
     }
   }


### PR DESCRIPTION
Kotest `StringSpec` test blocks take a `suspend TestScope.() -> Unit`, so each test body is already a coroutine. Wrapping it in `runBlocking { … }` is redundant and a recognized anti-pattern — it starts a nested event loop and blocks the test's carrier thread, sitting outside the test's own structured concurrency/cancellation.

This removes the `runBlocking { }` wrapper from every test that had it and calls the `suspend` APIs (`pool.eval`, `withSuspendingRedis*`, `withTimeout`) directly from the suspend test body, dropping the now-unused `runBlocking` imports.

| File | Wrappers removed |
|---|---|
| `script-utils-kotlin/ScriptPoolContractTests` | 6 |
| `script-utils-kotlin/BugFixVerificationTests` | 1 |
| `script-utils-java/JavaScriptTests` | 1 |
| `redis-utils/BugFixVerificationTests` | 3 |

Pure de-nesting, **no behavior change** — all three affected modules pass `check` (tests + Kotlinter + Detekt + Kover) unchanged. The non-suspending `withRedis`/`withRedisPool` tests (which never used `runBlocking`) are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)