### PR TITLE
Document the 2.9.0 release and bump versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,87 @@
 
 All notable changes to Common Utils are documented in this file.
 
-## [2.8.3] - 2026-05-09
+## [2.9.0] - 2026-06-03
 
-- Wire **Detekt** into every subproject via `configureDetekt()` in the root `build.gradle.kts`, with HTML/checkstyle reports per module and auto-detection of optional `config/detekt/detekt.yml` and `config/detekt/baseline.xml`
-- Upgrade **Detekt** to `2.0.0-alpha.3` (plugin id `dev.detekt`), migrate the Gradle DSL to the Property API, and wire the aggregate `detekt` task to depend on `detektMain`/`detektTest` so analysis runs with full type resolution
-- Activate `LongMethod`; suppress `IgnoredReturnValue`
-- Resolve type-resolution findings surfaced by the Detekt 2.0 upgrade across `core-utils`, `ktor-server-utils`, `script-utils-common`, `script-utils-kotlin`, `script-utils-java`, `script-utils-python`, `guava-utils`, and `service-utils`
-- Add a `config/detekt/detekt.yml` tailored for a multi-module utility library (disables threshold-style rules, excludes test code from `EmptyFunctionBlock` / `VariableNaming`); resolve the remaining real findings in `core-utils`, `script-utils-kotlin`, and `json-utils` tests
-- Add `grpc-utils` tests: `TlsUtilsTests` (11 cases) and `ServerExtensionsTests` (5 cases); add `mockk` to `grpc-utils` test dependencies
-- Centralize the Gradle wrapper version (`9.5.0`) and JVM target (`17`) under a `# Toolchain` section in `gradle/libs.versions.toml`; consume them from `build.gradle.kts` and the `Makefile`'s `upgrade-wrapper` target
-- Consolidate duplicated string literals in `build.gradle.kts` (`common-utils`, `"17"`, `config/detekt`) into named vals
-- Add `make detekt` and `make detekt-baseline` targets; `make lint` now also runs Detekt
-- Add `make help` for a self-documenting target list, parsed from `## description` comments
+### Breaking changes
+
+- `JavaScript.eval`/`evalScript` now return `Any?` instead of `Any`, so a null script result is returned honestly (fixes a `NullPointerException` on `eval("null")`); binary-compatible, source-breaking only for Kotlin callers that bound the result to a non-null type, and aligns `JavaScript` with `KotlinScript`/`PythonScript`
+- `KtorServletRequest.getContentType()` now returns `String?` and yields `null` when no `Content-Type` header is present, matching the `HttpServletRequest` contract (previously returned `"*/*"`)
+- Remove the always-false `isJava6` public val from `guava-utils`
+
+### Bug fixes
+
+- `ContentSource.GitLabFile` uses `repo.domainName` instead of a hardcoded `gitlab.com`, so self-hosted GitLab instances resolve correctly
+- `ListUtils.listPrint` quotes String elements per element instead of casting the whole list, fixing a `ClassCastException` on mixed-type lists
+- `InstrumentedThreadFactory` increments terminated before decrementing running, so a concurrent scrape never sees `running + terminated < created`
+- `AbstractExprEvaluator.compute()` returns `Any?` and propagates null instead of throwing on a null expression result
+- `String.singleToDoubleQuoted()` now escapes inner double quotes per its KDoc (`te"st` → `"te\"st"`)
+- `AbstractGenericService` removes its JVM shutdown hook on `shutDown()`, fixing a hook leak that left one hook registered per service instance for the life of the JVM
+- `UpsertStatement` emits `DO NOTHING` when every inserted column is part of the conflict key, instead of generating a dangling `DO UPDATE SET` that PostgreSQL rejects
+- `SamplerGaugeCollector` validates `labelNames`/`labelValues` sizes at construction (fail-fast) instead of throwing on every Prometheus scrape; `collect()` now guards the user-supplied sampler with `runCatching` and reports `Double.NaN` instead of aborting the whole scrape
+- `GenericValueWaiter`/`BooleanWaiter` support concurrent waiters via per-call `(predicate, continuation)` pairs under a lock, fixing waiters clobbering each other; also fixes a liveness bug where a satisfied wait could stall for the full timeout, and isolates a throwing predicate so it no longer starves the other waiters
+- `ZipExtensions.unzip()` decodes non-gzipped bytes explicitly as UTF-8 (was the JVM default charset, which corrupted non-ASCII content on a non-UTF-8 JVM)
+- `String.obfuscate()` requires `freq > 0` instead of throwing `ArithmeticException` (divide by zero)
+- `MiscJavaFuncs.random(int)`/`random(long)` use the unbiased `nextInt`/`nextLong(bound)`, removing modulo bias and rejecting `bound <= 0`
+- `MiscJavaFuncs.sleepMillis` restores the thread interrupt flag when `Thread.sleep` is interrupted
+- `KtorServletResponse` backs its header map with a case-insensitive `TreeMap` per RFC 9110 §5.1 / the `HttpServletResponse` contract
+
+### New features
+
+- Add a `ByteArray.zip()` GZIP overload mirroring `String.zip()`, avoiding a redundant UTF-8 re-encode for callers that already hold bytes
+- Broaden `isValidEmail()` to accept plus-addressing (`user+tag@example.com`), TLDs longer than four characters (`.travel`, `.email`), and single-character domain labels (`user@x.io`), while still rejecting clearly invalid input
+
+### Refactoring & internals
+
+- Extract `AbstractGenericService<T>` to de-duplicate the ~95% identical `GenericService` and `GenericKtorService` base classes; public API unchanged
+- Centralize JVM-termination detection in a new `ScriptGuards` (script-utils-common), broadened to cover `System.exit`, `kotlin.system.exitProcess`, and `Runtime.exit`/`halt` across the Kotlin and Java engines; documented everywhere as best-effort guards against accidental termination, **not** a security sandbox
+- Remove `LameBooleanWaiter` (a redundant, lower-quality duplicate of `BooleanWaiter`)
+- Dead-code sweep: remove unreachable branches, dead fallbacks, a shipped `Example.kt` demo, and stale suppressions across eight modules
+- Idiomatic-Kotlin and small performance cleanups (single-pass JSON path walks, a cached default `Json`, `joinToString` hex building, `toXOrNull()` numeric checks, etc.), each behavior-equivalence verified
+- Refactor four convoluted-logic targets (`Duration.format`, `BooleanMonitor` init, `JavaScript.javaEquiv`, and `KtorServletRequest` case-insensitive parameter access) with characterization tests
+
+### Documentation
+
+- KDoc accuracy fixes across dropwizard-utils, recaptcha-utils, exposed-utils, json-utils, redis-utils, and script-utils-common so the public docs match actual behavior
+
+### Tests
+
+- Add `grpc-utils` tests: `TlsUtilsTests` (11 cases) and `ServerExtensionsTests` (5 cases) covering trust/cert/key validation, `TlsContext.desc()`, `PLAINTEXT_CONTEXT`, graceful-shutdown ordering, and the `require(timeout > 0)` precondition; add `mockk` to `grpc-utils` test dependencies
+- Add tests for open coverage gaps across six modules (script-utils-kotlin, recaptcha-utils, jetty-utils, email-utils, and others)
+- Drop redundant `runBlocking { }` wrappers from suspend Kotest test bodies in script-utils-kotlin, script-utils-java, and redis-utils
+
+### Static analysis & coverage
+
+- Wire **Detekt** into every subproject via `configureDetekt()` in the root `build.gradle.kts`, with HTML/checkstyle reports per module and auto-detection of optional `config/detekt/detekt.yml` and `config/detekt/baseline.xml`; `make lint` now also runs Detekt
+- Add a `config/detekt/detekt.yml` tailored for a multi-module utility library (disables threshold-style rules, excludes test code from `EmptyFunctionBlock` / `VariableNaming`); activate `LongMethod`, suppress `IgnoredReturnValue`, and resolve the type-resolution findings surfaced by the upgrade across eight modules
+- Add `make detekt` and `make detekt-baseline` targets
 - Add Kover coverage subcommands: `coverage-html`, `coverage-log`, `coverage-verify`, `coverage-open`, `coverage-packages`, `coverage-clean`; `make coverage` now generates both HTML and XML
 - Move the `coverage-packages` inline Python to `scripts/coverage-packages.py` with a friendlier missing-report error
+
+### Build & tooling
+
+- Tidy Gradle config: organize `gradle/libs.versions.toml` into functional categories, alphabetize the scripting module includes, and dedupe the Kover excludes comment
+- Centralize the Gradle wrapper version and JVM target (`17`) under a `# Toolchain` section in `gradle/libs.versions.toml`, consumed from `build.gradle.kts` and the `Makefile`'s `upgrade-wrapper` target
+- Consolidate duplicated string literals in `build.gradle.kts` (`common-utils`, `"17"`, `config/detekt`) into named vals
+- Add `make help` for a self-documenting target list, parsed from `## description` comments
 - Add fail-fast guards in the `Makefile` when `VERSION` or `GRADLE_VERSION` cannot be parsed, instead of silently passing empty strings to publish/wrapper commands
 - Pass `ORG_GRADLE_PROJECT_signingInMemoryKeyId` in `GPG_ENV` so the in-memory signing plugin has all three required properties
 - Drop the unused `compile` alias from the `Makefile`
+
+### Dependencies
+
+- Add **Detekt** `2.0.0-alpha.3` (plugin id `dev.detekt`), with the aggregate `detekt` task depending on the per-source-set `detektMain`/`detektTest` tasks so analysis runs with full type resolution
+- Upgrade Gradle wrapper 9.5.0 → 9.5.1
+- Bump `kotlin` 2.3.21 → 2.4.0
 - Bump `kotlinx-coroutines` 1.10.2 → 1.11.0
-- Switch `kotlinx-datetime` from `0.7.1-0.6.x-compat` to `0.7.1` (drops the Exposed/jodatime-compat suffix)
-- Bump project version to 2.8.3
+- Bump `ktor` 3.4.3 → 3.5.0
+- Bump `exposed` 1.2.0 → 1.3.0
+- Bump `jetty` 12.1.8 → 12.1.10
+- Bump `redis` 7.5.0 → 7.5.2
+- Bump `logging` 8.0.1 → 8.0.4
+- Bump `dropwizard` 4.2.38 → 4.2.39
+- Add `h2` 2.3.232 as a test dependency
+- Bump project version to 2.9.0
 
 ## [2.8.2] - 2026-05-02
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,8 @@ These opt-ins are enabled globally:
 
 ### Key Technologies
 
-- Kotlin 2.3.21 with JVM target 17
-- Gradle 9.5.0 with Kotlin DSL
+- Kotlin 2.4.0 with JVM target 17
+- Gradle 9.5.1 with Kotlin DSL
 - Kotest + MockK for testing
 - Kotlinter for linting
 
@@ -109,6 +109,6 @@ All modules use: `com.pambrose.common.*`
 
 ### Version Management
 
-- Project version: "2.8.3" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
+- Project version: "2.9.0" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
 - Group: "com.pambrose.common-utils" (set in `gradle.properties`)
 - All library versions in `gradle/libs.versions.toml`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,40 +5,82 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
-## v2.8.3 — 2026-05-09
+## v2.9.0 — 2026-06-03
 
 ### Highlights
 
-- **Detekt 2.0 with type resolution**: Upgraded Detekt to 2.0.0-alpha.3 (plugin id `dev.detekt`), migrated the Gradle DSL to the Property API, and wired the aggregate `detekt` task to depend on the per-source-set `detektMain` / `detektTest` tasks so analysis runs with full type resolution. Type-resolved rules now catch issues like `ImplicitDefaultLocale`, `UnsafeCallOnNullableType`, `SleepInsteadOfDelay`, `InjectDispatcher`, and `ArrayPrimitive`.
-- **Detekt static analysis** wired into every subproject with HTML/checkstyle reports per module, a tailored `config/detekt/detekt.yml`, and an optional shared `config/detekt/baseline.xml`. `make detekt` is a first-class target and `make lint` includes it.
-- **Centralized toolchain**: Moved the Gradle wrapper version (9.5.0) and JVM target (17) into `gradle/libs.versions.toml` under a new `# Toolchain` section, consumed from both `build.gradle.kts` and the `Makefile`.
-- **Self-documenting Makefile**: New `make help` target prints every available target with its description, parsed from `## description` comments.
+- **Codebase-review hardening sweep**: A systematic review across all modules drove a large batch of correctness fixes — a leaked JVM shutdown hook in the service lifecycle, a metrics race in `InstrumentedThreadFactory`, modulo bias in `random()`, an UPSERT that emitted invalid SQL, concurrent-waiter clobbering in `GenericValueWaiter`/`BooleanWaiter`, and more.
+- **Service base-class consolidation**: `GenericService` and `GenericKtorService` were ~95% identical; their shared machinery now lives in a new `AbstractGenericService<T>` base class, with each subclass keeping only its servlet-hosting specifics. Public API is unchanged.
+- **Scripting exit guards centralized**: A new `ScriptGuards` (in script-utils-common) unifies JVM-termination detection across the Kotlin and Java engines and broadens it to cover `exitProcess` and `Runtime.exit`/`halt`. Documented prominently as best-effort guards against *accidental* termination, **not** a security sandbox.
+- **Detekt 2.0 static analysis**: Wired Detekt 2.0.0-alpha.3 (plugin id `dev.detekt`) into every subproject with full type resolution, HTML/checkstyle reports per module, and a tailored `config/detekt/detekt.yml`. `make detekt` is a first-class target and `make lint` includes it.
+- **Kotlin 2.4.0**: Upgraded to the final Kotlin 2.4.0 release.
 
-### Build improvements
+### Breaking changes
 
-- Consolidated duplicated string literals in `build.gradle.kts` (`common-utils`, `"17"`, `config/detekt`) into named vals.
-- Added Kover coverage subcommands: `coverage-html`, `coverage-log`, `coverage-verify`, `coverage-open`, `coverage-packages`, `coverage-clean`. `make coverage` now generates both HTML and XML.
-- Moved `coverage-packages` inline Python to `scripts/coverage-packages.py` with a friendlier missing-report error.
-- Added fail-fast guards so the `Makefile` errors clearly when `VERSION` or `GRADLE_VERSION` cannot be parsed.
-- Passed `ORG_GRADLE_PROJECT_signingInMemoryKeyId` in `GPG_ENV` so the in-memory signing plugin has all three required properties.
-- Dropped the unused `compile` Makefile alias.
+- `JavaScript.eval`/`evalScript` now return `Any?` instead of `Any`, so a null script result is returned honestly (fixing a `NullPointerException` on `eval("null")`). Binary-compatible; source-breaking only for Kotlin callers that bound the result to a non-null type — exactly the call sites that previously hit the runtime NPE. Aligns `JavaScript` with `KotlinScript`/`PythonScript`.
+- `KtorServletRequest.getContentType()` now returns `String?` and yields `null` when no `Content-Type` header is present, matching the `HttpServletRequest` contract (previously returned `"*/*"`).
+- Removed the always-false `isJava6` public val from `guava-utils`.
 
-### Detekt rule tuning
+### Bug fixes
 
-- Activated `LongMethod`; suppressed `IgnoredReturnValue`.
-- Resolved type-resolution findings surfaced by the upgrade across `core-utils`, `ktor-server-utils`, `script-utils-common`, `script-utils-kotlin`, `script-utils-java`, `script-utils-python`, `guava-utils`, and `service-utils` (locale-aware formatting, `orEmpty()` over `?: emptyList()`, `delay()` over `Thread.sleep()` in suspend tests, removed unnecessary `apply` blocks, removed unused variables, etc.).
+- `ContentSource.GitLabFile` resolves against `repo.domainName` instead of a hardcoded `gitlab.com`, so self-hosted GitLab instances work.
+- `ListUtils.listPrint` quotes String elements per element, fixing a `ClassCastException` on mixed-type lists.
+- `AbstractExprEvaluator.compute()` returns `Any?` and propagates null instead of throwing.
+- `String.singleToDoubleQuoted()` now escapes inner double quotes per its KDoc.
+- `AbstractGenericService` removes its JVM shutdown hook on `shutDown()`, fixing a hook leak (one hook per service instance for the life of the JVM).
+- `UpsertStatement` emits `DO NOTHING` when every inserted column is part of the conflict key, instead of a dangling `DO UPDATE SET` that PostgreSQL rejects.
+- `SamplerGaugeCollector` validates label sizes at construction (fail-fast); `collect()` guards the user-supplied sampler with `runCatching` and reports `Double.NaN` instead of aborting the whole scrape.
+- `GenericValueWaiter`/`BooleanWaiter` support concurrent waiters, with the satisfied-wait liveness bug and throwing-predicate starvation both fixed and regression-tested.
+- `ZipExtensions.unzip()` decodes non-gzipped bytes explicitly as UTF-8.
+- `String.obfuscate()` requires `freq > 0` instead of throwing `ArithmeticException`.
+- `MiscJavaFuncs.random(int)`/`random(long)` use the unbiased `nextInt`/`nextLong(bound)` and reject `bound <= 0`; `sleepMillis` restores the interrupt flag when interrupted.
+- `KtorServletResponse` headers are now case-insensitive per RFC 9110 §5.1.
 
-### Dependency bumps
+### New features
 
-- `kotlinx-coroutines` 1.10.2 → 1.11.0
-- `kotlinx-datetime` 0.7.1-0.6.x-compat → 0.7.1 (drops the Exposed/jodatime-compat suffix)
-- `detekt` plugin 1.23.8 → 2.0.0-alpha.3
+- `ByteArray.zip()` GZIP overload mirroring `String.zip()`, avoiding a redundant UTF-8 re-encode for callers that already hold bytes.
+- Broader `isValidEmail()`: accepts plus-addressing (`user+tag@example.com`), long TLDs (`.travel`, `.email`), and single-character domain labels (`user@x.io`), while still rejecting clearly invalid input.
+
+### Refactoring & internals
+
+- Removed `LameBooleanWaiter` (a redundant duplicate of `BooleanWaiter`).
+- Dead-code sweep across eight modules (unreachable branches, dead fallbacks, a shipped `Example.kt` demo, stale suppressions).
+- Idiomatic-Kotlin and small performance cleanups (single-pass JSON path walks, a cached default `Json`, `joinToString` hex building, `toXOrNull()` numeric checks), each behavior-equivalence verified.
+- Refactored four convoluted-logic targets (`Duration.format`, `BooleanMonitor`, `JavaScript.javaEquiv`, `KtorServletRequest` parameter access) with characterization tests.
+
+### Documentation
+
+- KDoc accuracy fixes across dropwizard-utils, recaptcha-utils, exposed-utils, json-utils, redis-utils, and script-utils-common.
 
 ### Tests
 
-- Added `grpc-utils` tests: `TlsUtilsTests` (11 cases) and `ServerExtensionsTests` (5 cases) covering trust/cert/key validation, `TlsContext.desc()` branches, `PLAINTEXT_CONTEXT`, graceful shutdown ordering, and the `require(timeout > 0)` precondition. Added `mockk` to `grpc-utils` test dependencies.
+- Added `grpc-utils` tests: `TlsUtilsTests` (11 cases) and `ServerExtensionsTests` (5 cases) covering trust/cert/key validation, `TlsContext.desc()` branches, `PLAINTEXT_CONTEXT`, graceful-shutdown ordering, and the `require(timeout > 0)` precondition. Added `mockk` to `grpc-utils` test dependencies.
+- Added tests for open coverage gaps across six modules.
+- Dropped redundant `runBlocking { }` wrappers from suspend Kotest test bodies in script-utils-kotlin, script-utils-java, and redis-utils.
 
-**Full Changelog**: https://github.com/pambrose/common-utils/compare/2.8.2...2.8.3
+### Static analysis, coverage & tooling
+
+- Wired **Detekt** into every subproject via `configureDetekt()` with HTML/checkstyle reports per module and auto-detection of an optional `config/detekt/detekt.yml` and shared `config/detekt/baseline.xml`. Added a tailored `config/detekt/detekt.yml`, activated `LongMethod`, suppressed `IgnoredReturnValue`, and resolved the type-resolution findings surfaced across eight modules. Added `make detekt` / `make detekt-baseline`.
+- Added Kover coverage subcommands: `coverage-html`, `coverage-log`, `coverage-verify`, `coverage-open`, `coverage-packages`, `coverage-clean`. `make coverage` now generates both HTML and XML. Moved the `coverage-packages` inline Python to `scripts/coverage-packages.py`.
+- Organized `gradle/libs.versions.toml` into functional categories and centralized the Gradle wrapper version and JVM target (17) under a `# Toolchain` section, consumed from both `build.gradle.kts` and the `Makefile`.
+- Consolidated duplicated string literals in `build.gradle.kts` into named vals.
+- Added `make help`, a self-documenting target list parsed from `## description` comments, plus fail-fast guards when `VERSION` / `GRADLE_VERSION` cannot be parsed. Passed `ORG_GRADLE_PROJECT_signingInMemoryKeyId` in `GPG_ENV`, and dropped the unused `compile` Makefile alias.
+
+### Dependency bumps
+
+- Added **Detekt** plugin `2.0.0-alpha.3` (`dev.detekt`)
+- Gradle wrapper 9.5.0 → 9.5.1
+- `kotlin` 2.3.21 → 2.4.0
+- `kotlinx-coroutines` 1.10.2 → 1.11.0
+- `ktor` 3.4.3 → 3.5.0
+- `exposed` 1.2.0 → 1.3.0
+- `jetty` 12.1.8 → 12.1.10
+- `redis` 7.5.0 → 7.5.2
+- `logging` 8.0.1 → 8.0.4
+- `dropwizard` 4.2.38 → 4.2.39
+- Added `h2` 2.3.232 as a test dependency
+
+**Full Changelog**: https://github.com/pambrose/common-utils/compare/2.8.2...2.9.0
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ kover = "0.9.8"
 mavenPublish = "0.36.0"
 
 # Kotlin & kotlinx
-kotlin = "2.4.0-RC2"
+kotlin = "2.4.0"
 coroutines = "1.11.0"
 datetime = "0.7.1-0.6.x-compat"
 kotlinxHtml = "0.12.0"
@@ -24,14 +24,14 @@ logging = "8.0.4"
 dropwizard = "4.2.39"
 grpc = "1.81.0"
 jakartaServlet = "6.1.0"
-jetty = "12.1.9"
+jetty = "12.1.10"
 ktor = "3.5.0"
 nettyTcNative = "2.0.77.Final"
 
 # Data
 exposed = "1.3.0"
 h2 = "2.3.232"
-redis = "7.5.0"
+redis = "7.5.2"
 
 # Scripting
 javaScripting = "2.0.0"

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,7 @@
 - Repository: https://github.com/pambrose/common-utils
 - Maven Central: https://central.sonatype.com/namespace/com.pambrose.common-utils
 - License: Apache 2.0
-- Kotlin: 2.3.21, JVM 17
+- Kotlin: 2.4.0, JVM 17
 - Base package: com.pambrose.common.*
 - Install: `implementation("com.pambrose.common-utils:<module>:2.9.0")`
 


### PR DESCRIPTION
## Summary

Prepares the docs and version metadata for the **2.9.0** release (dated 2026-06-03). Since **2.8.3 was never released/tagged**, its content is folded into 2.9.0, which now covers everything since the 2.8.2 tag.

- **CHANGELOG.md** — single `## [2.9.0]` entry: breaking changes, bug fixes, new features, refactors, docs, tests, static analysis & coverage, build & tooling, and dependencies. The former 2.8.3 section is removed.
- **RELEASE_NOTES.md** — single `v2.9.0` entry with a Detekt highlight and merged tooling section; diff link set to `2.8.2...2.9.0`.
- **CLAUDE.md / llms.txt** — version → 2.9.0, Kotlin → 2.4.0, Gradle → 9.5.1 (were stale).
- **gradle/libs.versions.toml** — finalize dependency bumps (Kotlin 2.4.0, Jetty 12.1.10, Redis 7.5.2).

## Accuracy corrections vs. the un-released 2.8.3 notes

Reconciled against the actual `2.8.2..HEAD` catalog diff rather than trusting the un-released 2.8.3 notes:

- **`kotlinx-datetime` is unchanged** (still `0.7.1-0.6.x-compat`) — the old 2.8.3 note claimed a switch to `0.7.1` that isn't in the tree, so it was dropped.
- Dependency bumps are now stated from the real 2.8.2 baseline: `kotlin` 2.3.21→2.4.0, `ktor` 3.4.3→3.5.0, `exposed` 1.2.0→1.3.0, `jetty` 12.1.8→12.1.10, `logging` 8.0.1→8.0.4, Gradle wrapper 9.5.0→9.5.1, plus the new `h2` test dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)