### PR TITLE
Replace custom UpsertStatement with Exposed's native upsert and bump gRPC to 1.82.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Common Utils are documented in this file.
 
+## [2.9.1] - 2026-06-11
+
+### Breaking changes
+
+- `Table.upsert` (exposed-utils) is now a thin overload of Exposed's native `upsert` and takes only a unique `Index` as the conflict target (`upsert(conflictIndex = myUniqueIndex) { ... }`). The hand-rolled `UpsertStatement` class and the `conflictColumn` parameter have been removed; pass a single-column unique index instead of a column. The lambda receiver is now Exposed's `org.jetbrains.exposed.v1.core.statements.UpsertStatement<Long>`.
+
+### Refactoring & internals
+
+- Replace the custom `UpsertStatement` and its `prepareSQL` override with a forwarding call to Exposed's native `upsert`, keeping named index definitions as the single source of truth for conflict columns while letting Exposed generate the `ON CONFLICT` SQL
+
+### Dependency bumps
+
+- `grpc` 1.81.0 → 1.82.0
+- `netty-tcnative-boringssl-static` pinned to 2.0.75.Final to match gRPC 1.82.0 (catalog alias `netty-ssl` renamed to `netty-tcnative`)
+
 ## [2.9.0] - 2026-06-03
 
 ### Breaking changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,6 @@ All modules use: `com.pambrose.common.*`
 
 ### Version Management
 
-- Project version: "2.9.0" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
+- Project version: "2.9.1" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
 - Group: "com.pambrose.common-utils" (set in `gradle.properties`)
 - All library versions in `gradle/libs.versions.toml`

--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ This library is available on [Maven Central](https://central.sonatype.com/artifa
 ```kotlin
 dependencies {
     // Include specific modules as needed
-  implementation("com.pambrose.common-utils:core-utils:2.9.0")
-  implementation("com.pambrose.common-utils:json-utils:2.9.0")
-  implementation("com.pambrose.common-utils:ktor-server-utils:2.9.0")
+  implementation("com.pambrose.common-utils:core-utils:2.9.1")
+  implementation("com.pambrose.common-utils:json-utils:2.9.1")
+  implementation("com.pambrose.common-utils:ktor-server-utils:2.9.1")
     // ... other modules
 }
 ```
@@ -212,7 +212,7 @@ dependencies {
     <dependency>
         <groupId>com.pambrose.common-utils</groupId>
         <artifactId>core-utils</artifactId>
-      <version>2.9.0</version>
+      <version>2.9.1</version>
     </dependency>
     <!-- Add other modules as needed -->
 </dependencies>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,26 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
+## v2.9.1 — 2026-06-11
+
+### Highlights
+
+- **Native Exposed upsert**: `Table.upsert` is now a thin convenience overload of Exposed's own `upsert`. The hand-rolled `UpsertStatement` (with its custom `prepareSQL` building the `ON CONFLICT` clause) is gone — the overload simply forwards a unique `Index`'s columns as the conflict keys, so named index definitions stay the single source of truth while Exposed generates the SQL.
+- **gRPC 1.82.0**: Bumped gRPC and pinned `netty-tcnative-boringssl-static` to the matching 2.0.75.Final.
+
+### Breaking changes
+
+- `Table.upsert` takes only a unique `Index` as the conflict target (`upsert(conflictIndex = myUniqueIndex) { ... }`); the `conflictColumn` parameter and the custom `UpsertStatement` class have been removed. Callers that passed a single column should pass a single-column unique index. The lambda receiver is now Exposed's `org.jetbrains.exposed.v1.core.statements.UpsertStatement<Long>`.
+
+### Dependency bumps
+
+- `grpc` 1.81.0 → 1.82.0
+- `netty-tcnative-boringssl-static` pinned to 2.0.75.Final (catalog alias `netty-ssl` → `netty-tcnative`)
+
+**Full Changelog**: https://github.com/pambrose/common-utils/compare/2.9.0...2.9.1
+
+---
+
 ## v2.9.0 — 2026-06-03
 
 ### Highlights

--- a/exposed-utils/README.md
+++ b/exposed-utils/README.md
@@ -78,22 +78,27 @@ println("Row data: ${row.toRowString()}")
 
 ```kotlin
 import com.pambrose.common.exposed.upsert
-import org.jetbrains.exposed.v1.jdbc.insert
 
-// Upsert with conflict on constraint
-MyTable.upsert(conflictIndex = "unique_email_idx") {
+object MyTable : Table("my_table") {
+  val name = varchar("name", 255)
+  val email = varchar("email", 255)
+  val updatedAt = long("updated_at")
+
+  // Declare the unique index used as the conflict target
+  val uniqueEmail = uniqueIndex("unique_email_idx", email)
+}
+
+// Upsert with the unique index as the conflict target.
+// `conflictIndex` forwards the index's columns as the `ON CONFLICT (...)` keys,
+// delegating to Exposed's native upsert.
+MyTable.upsert(conflictIndex = MyTable.uniqueEmail) {
   it[name] = "John Doe"
   it[email] = "john@example.com"
   it[updatedAt] = System.currentTimeMillis()
 }
-
-// Upsert with conflict on column
-MyTable.upsert(conflictColumn = MyTable.email) {
-  it[name] = "Jane Doe"
-  it[email] = "jane@example.com"
-  it[updatedAt] = System.currentTimeMillis()
-}
 ```
+
+> **Note**: As of 2.9.1, `upsert` is a thin convenience overload of Exposed's native `upsert` and accepts only a unique `Index` as the conflict target. To conflict on a single column, declare a single-column `uniqueIndex` and pass it.
 
 ## Dependencies
 

--- a/exposed-utils/src/main/kotlin/com/pambrose/common/exposed/UpsertStatement.kt
+++ b/exposed-utils/src/main/kotlin/com/pambrose/common/exposed/UpsertStatement.kt
@@ -16,85 +16,18 @@
 
 package com.pambrose.common.exposed
 
-import com.pambrose.common.util.isNotNull
-import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.Index
-import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.Table
-import org.jetbrains.exposed.v1.core.Transaction
-import org.jetbrains.exposed.v1.core.statements.InsertStatement
-import org.jetbrains.exposed.v1.jdbc.statements.toExecutable
-import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.core.statements.UpsertStatement
+import org.jetbrains.exposed.v1.jdbc.upsert
 
 /**
- * Performs an UPSERT (INSERT ... ON CONFLICT DO UPDATE) on this [Table].
- *
- * Extension function on [Table]. Exactly one of [conflictColumn] or [conflictIndex] must be provided
- * to identify the unique constraint for conflict detection.
- *
- * @param T the table type
- * @param conflictColumn the unique column to use for conflict detection
- * @param conflictIndex the unique index to use for conflict detection
- * @param body the insert body specifying column values
- * @return the executed [UpsertStatement]
+ * Convenience overload of Exposed's native [upsert] that takes a unique [Index] as the conflict target,
+ * forwarding its columns as the `keys` of the underlying `ON CONFLICT (...)` clause. This keeps the named
+ * index definitions in `PostgresTables.kt` as the single source of truth for conflict columns while using
+ * Exposed's upsert directly.
  */
-inline fun <T : Table> T.upsert(
-  conflictColumn: Column<*>? = null,
-  conflictIndex: Index? = null,
-  body: T.(UpsertStatement<Number>) -> Unit,
-): UpsertStatement<Number> =
-  UpsertStatement<Number>(this, conflictColumn, conflictIndex)
-    .apply {
-      body(this)
-      toExecutable().execute(TransactionManager.current())
-    }
-
-/**
- * An [InsertStatement] that appends a PostgreSQL `ON CONFLICT ... DO UPDATE SET` clause.
- *
- * Generates SQL that inserts a row and, on conflict with the specified column or index constraint,
- * updates all non-conflict columns to their `EXCLUDED` values — or emits `DO NOTHING` when every
- * inserted column belongs to the conflict key, since there is then nothing to update.
- *
- * @param Key the auto-generated key type
- * @param table the target table
- * @param conflictColumn the unique column for conflict detection (mutually exclusive with [conflictIndex])
- * @param conflictIndex the unique index for conflict detection (mutually exclusive with [conflictColumn])
- * @throws IllegalArgumentException if neither [conflictColumn] nor [conflictIndex] is provided
- */
-class UpsertStatement<Key : Any>(
-  table: Table,
-  conflictColumn: Column<*>? = null,
-  conflictIndex: Index? = null,
-) : InsertStatement<Key>(table, false) {
-  private val indexColumns: List<Column<*>> =
-    when {
-      conflictIndex.isNotNull() -> conflictIndex.columns
-      conflictColumn.isNotNull() -> listOf(conflictColumn)
-      else -> throw IllegalArgumentException("Either conflictColumn or conflictIndex must be provided")
-    }
-
-  @OptIn(InternalApi::class)
-  override fun prepareSQL(
-    transaction: Transaction,
-    prepared: Boolean,
-  ): String =
-    buildString {
-      append(super.prepareSQL(transaction, prepared))
-      // Use the column-inference form `ON CONFLICT (cols)` rather than `ON CONFLICT ON CONSTRAINT`:
-      // it resolves the arbiter from the conflict columns and works for both a unique column and a
-      // unique index, whereas ON CONSTRAINT requires an actual constraint name.
-      append(" ON CONFLICT ")
-      indexColumns.joinTo(this, separator = ", ", prefix = "(", postfix = ")") { transaction.identity(it) }
-
-      val updateColumns = values.keys.filter { it !in indexColumns }
-      if (updateColumns.isEmpty()) {
-        // Every inserted column is part of the conflict key, so there is nothing to update.
-        // `DO UPDATE SET` with no assignments is invalid SQL; `DO NOTHING` is the correct no-op.
-        append(" DO NOTHING")
-      } else {
-        append(" DO UPDATE SET ")
-        updateColumns.joinTo(this) { "${transaction.identity(it)}=EXCLUDED.${transaction.identity(it)}" }
-      }
-    }
-}
+fun <T : Table> T.upsert(
+  conflictIndex: Index,
+  body: T.(UpsertStatement<Long>) -> Unit,
+): UpsertStatement<Long> = upsert(keys = conflictIndex.columns.toTypedArray(), body = body)

--- a/exposed-utils/src/test/kotlin/com/pambrose/common/exposed/BugFixVerificationTests.kt
+++ b/exposed-utils/src/test/kotlin/com/pambrose/common/exposed/BugFixVerificationTests.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldNotBeInstanceOf
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.statements.UpsertStatement
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
@@ -59,59 +60,6 @@ class BugFixVerificationTests : StringSpec() {
         timedReadOnlyTx(db = null) { }
       }
       exception.shouldNotBeInstanceOf<NullPointerException>()
-    }
-
-    // Bug #6: UpsertStatement emitted `ON CONFLICT ON CONSTRAINT <name>` using the column/index
-    // name as if it were a constraint name, which is invalid PostgreSQL unless a constraint happens
-    // to be named identically. It now uses the column-inference form `ON CONFLICT (<cols>)`.
-
-    "upsert with conflictColumn uses ON CONFLICT (column) not ON CONSTRAINT" {
-      Database.connect("jdbc:h2:mem:upsert_col;MODE=PostgreSQL;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
-      transaction {
-        val stmt = UpsertStatement<Number>(UpsertTestTable, conflictColumn = UpsertTestTable.email)
-        stmt[UpsertTestTable.id] = 1
-        stmt[UpsertTestTable.email] = "a@b.com"
-        stmt[UpsertTestTable.name] = "Alice"
-
-        val sql = stmt.prepareSQL(this, prepared = false)
-        sql shouldContain "ON CONFLICT ("
-        sql shouldContain "DO UPDATE SET"
-        sql shouldNotContain "ON CONSTRAINT"
-        // The conflict column is the arbiter; the non-conflict column is updated from EXCLUDED.
-        sql shouldContain "EXCLUDED"
-      }
-    }
-
-    "upsert with conflictIndex uses ON CONFLICT (columns) not ON CONSTRAINT" {
-      Database.connect("jdbc:h2:mem:upsert_idx;MODE=PostgreSQL;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
-      transaction {
-        val index = UpsertTestTable.indices.first()
-        val stmt = UpsertStatement<Number>(UpsertTestTable, conflictIndex = index)
-        stmt[UpsertTestTable.id] = 1
-        stmt[UpsertTestTable.email] = "a@b.com"
-        stmt[UpsertTestTable.name] = "Alice"
-
-        val sql = stmt.prepareSQL(this, prepared = false)
-        sql shouldContain "ON CONFLICT ("
-        sql shouldNotContain "ON CONSTRAINT"
-      }
-    }
-
-    // Bug: when every inserted column is part of the conflict key, the update-column list is empty,
-    // leaving a dangling `... DO UPDATE SET ` that PostgreSQL rejects. It must emit `DO NOTHING`.
-
-    "upsert with only conflict columns emits DO NOTHING instead of a dangling DO UPDATE SET" {
-      Database.connect("jdbc:h2:mem:upsert_nothing;MODE=PostgreSQL;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
-      transaction {
-        val stmt = UpsertStatement<Number>(UpsertTestTable, conflictColumn = UpsertTestTable.email)
-        // The only inserted column is the conflict column, so there is nothing to update.
-        stmt[UpsertTestTable.email] = "a@b.com"
-
-        val sql = stmt.prepareSQL(this, prepared = false)
-        sql shouldContain "ON CONFLICT ("
-        sql shouldContain "DO NOTHING"
-        sql shouldNotContain "DO UPDATE SET"
-      }
     }
   }
 }

--- a/exposed-utils/src/test/kotlin/com/pambrose/common/exposed/BugFixVerificationTests.kt
+++ b/exposed-utils/src/test/kotlin/com/pambrose/common/exposed/BugFixVerificationTests.kt
@@ -20,13 +20,8 @@ package com.pambrose.common.exposed
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldNotBeInstanceOf
 import org.jetbrains.exposed.v1.core.Table
-import org.jetbrains.exposed.v1.core.statements.UpsertStatement
-import org.jetbrains.exposed.v1.jdbc.Database
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 private object UpsertTestTable : Table("upsert_test") {
   val id = integer("id")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.pambrose.common-utils
-version=2.9.0
+version=2.9.1
 
 kotlin.code.style=official
 org.gradle.caching=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,11 +22,12 @@ logging = "8.0.4"
 
 # Frameworks
 dropwizard = "4.2.39"
-grpc = "1.81.0"
+grpc = "1.82.0"
 jakartaServlet = "6.1.0"
 jetty = "12.1.10"
 ktor = "3.5.0"
-nettyTcNative = "2.0.77.Final"
+# Keep in sync with grpc
+tcnative = "2.0.75.Final"
 
 # Data
 exposed = "1.3.0"
@@ -75,7 +76,7 @@ grpc-netty = { module = "io.grpc:grpc-netty", version.ref = "grpc" }
 grpc-protobuf = { module = "io.grpc:grpc-protobuf", version.ref = "grpc" }
 grpc-services = { module = "io.grpc:grpc-services", version.ref = "grpc" }
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
-netty-ssl = { module = "io.netty:netty-tcnative-boringssl-static", version.ref = "nettyTcNative" }
+netty-tcnative = { module = "io.netty:netty-tcnative-boringssl-static", version.ref = "tcnative" }
 
 # Frameworks -- Jakarta Servlet
 jakarta-servlet-api = { module = "jakarta.servlet:jakarta.servlet-api", version.ref = "jakartaServlet" }

--- a/grpc-utils/build.gradle.kts
+++ b/grpc-utils/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
 
     implementation(libs.bundles.grpc)
 
-    runtimeOnly(libs.netty.ssl)
+    runtimeOnly(libs.netty.tcnative)
 
     testImplementation(libs.mockk)
 }


### PR DESCRIPTION
## Summary

- Rework `Table.upsert` into a thin convenience overload of Exposed's native `upsert` that forwards a unique `Index`'s columns as the conflict keys. This deletes the hand-rolled `UpsertStatement` class and its `prepareSQL` override, letting Exposed handle the `ON CONFLICT` SQL generation while keeping named index definitions as the single source of truth for conflict columns.
- Drop the tests that covered the custom `prepareSQL` SQL generation (no longer applicable) and remove the imports they left behind.
- Bump `grpc` to 1.82.0 and pin `netty-tcnative-boringssl-static` to 2.0.75.Final to match, renaming the catalog alias `netty-ssl` to `netty-tcnative`.
- Bump project version to 2.9.1.

## Test plan

- [ ] `./gradlew :exposed-utils:test`
- [ ] `./gradlew :grpc-utils:test`
- [ ] `./gradlew build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)