### PR TITLE
Accept suspending blocks in respondWith/redirectTo and bump detekt to 2.0.0-alpha.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ gradle-wrapper = "9.5.1"
 jvmTarget = "17"
 
 # Plugins
-detekt = "2.0.0-alpha.3"
+detekt = "2.0.0-alpha.4"
 dokka = "2.2.0"
 gradlePlugins = "1.0.14"
 kover = "0.9.8"

--- a/ktor-server-utils/src/main/kotlin/com/pambrose/common/response/ResponseUtils.kt
+++ b/ktor-server-utils/src/main/kotlin/com/pambrose/common/response/ResponseUtils.kt
@@ -39,19 +39,6 @@ suspend inline fun ApplicationCall.respondWith(
 ) = respondText(block.invoke(), contentType)
 
 /**
- * Responds to the client with text content produced by [block].
- *
- * This is an extension function on [RoutingContext] that delegates to [ApplicationCall.respondWith].
- *
- * @param contentType the content type of the response; defaults to [ContentType.Text.Html]
- * @param block a lambda that returns the response body as a [String]
- */
-suspend inline fun RoutingContext.respondWith(
-  contentType: ContentType = Text.Html,
-  block: suspend () -> String,
-) = call.respondWith(contentType, block)
-
-/**
  * Redirects the client to the URL produced by [block].
  *
  * This is an extension function on [ApplicationCall]. The [block] is a suspending lambda; a
@@ -64,6 +51,19 @@ suspend inline fun ApplicationCall.redirectTo(
   permanent: Boolean = false,
   block: suspend () -> String,
 ) = respondRedirect(block.invoke(), permanent)
+
+/**
+ * Responds to the client with text content produced by [block].
+ *
+ * This is an extension function on [RoutingContext] that delegates to [ApplicationCall.respondWith].
+ *
+ * @param contentType the content type of the response; defaults to [ContentType.Text.Html]
+ * @param block a lambda that returns the response body as a [String]
+ */
+suspend inline fun RoutingContext.respondWith(
+  contentType: ContentType = Text.Html,
+  block: suspend () -> String,
+) = call.respondWith(contentType, block)
 
 /**
  * Redirects the client to the URL produced by [block].

--- a/ktor-server-utils/src/main/kotlin/com/pambrose/common/response/ResponseUtils.kt
+++ b/ktor-server-utils/src/main/kotlin/com/pambrose/common/response/ResponseUtils.kt
@@ -27,28 +27,16 @@ import io.ktor.server.routing.RoutingContext
 /**
  * Responds to the client with text content produced by [block].
  *
- * This is an extension function on [ApplicationCall].
+ * This is an extension function on [ApplicationCall]. The [block] is a suspending lambda; a
+ * non-suspending lambda is also accepted since `() -> String` is a subtype of `suspend () -> String`.
  *
  * @param contentType the content type of the response; defaults to [ContentType.Text.Html]
  * @param block a lambda that returns the response body as a [String]
  */
 suspend inline fun ApplicationCall.respondWith(
   contentType: ContentType = Text.Html,
-  block: () -> String,
+  block: suspend () -> String,
 ) = respondText(block.invoke(), contentType)
-
-/**
- * Redirects the client to the URL produced by [block].
- *
- * This is an extension function on [ApplicationCall].
- *
- * @param permanent whether to issue a 301 (permanent) redirect; defaults to `false` (302 temporary)
- * @param block a lambda that returns the redirect target URL as a [String]
- */
-suspend inline fun ApplicationCall.redirectTo(
-  permanent: Boolean = false,
-  block: () -> String,
-) = respondRedirect(block.invoke(), permanent)
 
 /**
  * Responds to the client with text content produced by [block].
@@ -60,8 +48,22 @@ suspend inline fun ApplicationCall.redirectTo(
  */
 suspend inline fun RoutingContext.respondWith(
   contentType: ContentType = Text.Html,
-  block: () -> String,
+  block: suspend () -> String,
 ) = call.respondWith(contentType, block)
+
+/**
+ * Redirects the client to the URL produced by [block].
+ *
+ * This is an extension function on [ApplicationCall]. The [block] is a suspending lambda; a
+ * non-suspending lambda is also accepted since `() -> String` is a subtype of `suspend () -> String`.
+ *
+ * @param permanent whether to issue a 301 (permanent) redirect; defaults to `false` (302 temporary)
+ * @param block a lambda that returns the redirect target URL as a [String]
+ */
+suspend inline fun ApplicationCall.redirectTo(
+  permanent: Boolean = false,
+  block: suspend () -> String,
+) = respondRedirect(block.invoke(), permanent)
 
 /**
  * Redirects the client to the URL produced by [block].
@@ -73,7 +75,7 @@ suspend inline fun RoutingContext.respondWith(
  */
 suspend inline fun RoutingContext.redirectTo(
   permanent: Boolean = false,
-  block: () -> String,
+  block: suspend () -> String,
 ) = call.redirectTo(permanent, block)
 
 /**

--- a/ktor-server-utils/src/test/kotlin/com/pambrose/common/response/ResponseUtilsTests.kt
+++ b/ktor-server-utils/src/test/kotlin/com/pambrose/common/response/ResponseUtilsTests.kt
@@ -30,6 +30,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.testing.testApplication
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.delay
 
 class ResponseUtilsTests : StringSpec() {
   init {
@@ -59,6 +60,23 @@ class ResponseUtilsTests : StringSpec() {
           status shouldBe HttpStatusCode.OK
           bodyAsText() shouldBe "hello"
           ContentType.parse(headers[HttpHeaders.ContentType]!!).match(ContentType.Text.Plain) shouldBe true
+        }
+      }
+    }
+
+    "ApplicationCall respondWith accepts a suspending block" {
+      testApplication {
+        routing {
+          get("/suspending") {
+            call.respondWith {
+              delay(1)
+              "<h1>suspended</h1>"
+            }
+          }
+        }
+        client.get("/suspending").apply {
+          status shouldBe HttpStatusCode.OK
+          bodyAsText() shouldBe "<h1>suspended</h1>"
         }
       }
     }
@@ -103,6 +121,24 @@ class ResponseUtilsTests : StringSpec() {
         val client = createClient { followRedirects = false }
         client.get("/old").apply {
           status shouldBe HttpStatusCode.MovedPermanently
+          headers[HttpHeaders.Location] shouldBe "/new"
+        }
+      }
+    }
+
+    "ApplicationCall redirectTo accepts a suspending block" {
+      testApplication {
+        routing {
+          get("/old") {
+            call.redirectTo {
+              delay(1)
+              "/new"
+            }
+          }
+        }
+        val client = createClient { followRedirects = false }
+        client.get("/old").apply {
+          status shouldBe HttpStatusCode.Found
           headers[HttpHeaders.Location] shouldBe "/new"
         }
       }


### PR DESCRIPTION
## Summary

- Widen the `respondWith`/`redirectTo` block parameters to `suspend () -> String` so suspending lambdas are accepted. Non-suspending lambdas remain valid since `() -> String` is a subtype of `suspend () -> String`.
- Reorder the `ApplicationCall.redirectTo` definition to sit alongside the other redirect helpers and update the KDoc to note the suspend acceptance.
- Bump detekt to `2.0.0-alpha.4`.

## Test plan

- `./gradlew :ktor-server-utils:build`
- `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)