### PR TITLE
Document the 2.9.2 release and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Common Utils are documented in this file.
 
+## [2.9.2] - 2026-06-14
+
+### New features
+
+- `ApplicationCall.respondWith`/`redirectTo` and their `RoutingContext` overloads (ktor-server-utils) now accept a `suspend () -> String` block, so the body/redirect-target lambda can call suspending functions. Existing non-suspending lambdas remain valid, since `() -> String` is a subtype of `suspend () -> String`.
+
+### Dependency bumps
+
+- `detekt` 2.0.0-alpha.3 → 2.0.0-alpha.4
+
 ## [2.9.1] - 2026-06-11
 
 ### Breaking changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,6 @@ All modules use: `com.pambrose.common.*`
 
 ### Version Management
 
-- Project version: "2.9.1" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
+- Project version: "2.9.2" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
 - Group: "com.pambrose.common-utils" (set in `gradle.properties`)
 - All library versions in `gradle/libs.versions.toml`

--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ This library is available on [Maven Central](https://central.sonatype.com/artifa
 ```kotlin
 dependencies {
     // Include specific modules as needed
-  implementation("com.pambrose.common-utils:core-utils:2.9.1")
-  implementation("com.pambrose.common-utils:json-utils:2.9.1")
-  implementation("com.pambrose.common-utils:ktor-server-utils:2.9.1")
+  implementation("com.pambrose.common-utils:core-utils:2.9.2")
+  implementation("com.pambrose.common-utils:json-utils:2.9.2")
+  implementation("com.pambrose.common-utils:ktor-server-utils:2.9.2")
     // ... other modules
 }
 ```
@@ -212,7 +212,7 @@ dependencies {
     <dependency>
         <groupId>com.pambrose.common-utils</groupId>
         <artifactId>core-utils</artifactId>
-      <version>2.9.1</version>
+      <version>2.9.2</version>
     </dependency>
     <!-- Add other modules as needed -->
 </dependencies>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,20 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
+## v2.9.2 — 2026-06-14
+
+### Highlights
+
+- **Suspending response blocks**: The `respondWith` and `redirectTo` helpers (ktor-server-utils), on both `ApplicationCall` and `RoutingContext`, now take a `suspend () -> String` block, so the body/redirect-target lambda can call suspending functions directly. The change is source-compatible — existing non-suspending lambdas still work, since `() -> String` is a subtype of `suspend () -> String`.
+
+### Dependency bumps
+
+- `detekt` 2.0.0-alpha.3 → 2.0.0-alpha.4
+
+**Full Changelog**: https://github.com/pambrose/common-utils/compare/2.9.1...2.9.2
+
+---
+
 ## v2.9.1 — 2026-06-11
 
 ### Highlights

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.pambrose.common-utils
-version=2.9.1
+version=2.9.2
 
 kotlin.code.style=official
 org.gradle.caching=true


### PR DESCRIPTION
## Summary

Prepares the 2.9.2 release:

- Bump the project version to `2.9.2` (`gradle.properties`) and update the version references in `CLAUDE.md` and the README install examples.
- Add `2.9.2` entries to `CHANGELOG.md` and `RELEASE_NOTES.md`.

## Changes since 2.9.1

- **New feature**: `respondWith`/`redirectTo` (both `ApplicationCall` and `RoutingContext`, ktor-server-utils) now accept a `suspend () -> String` block. Source-compatible — non-suspending lambdas remain valid since `() -> String` is a subtype of `suspend () -> String`.
- **Dependency bump**: `detekt` 2.0.0-alpha.3 → 2.0.0-alpha.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)