### PR TITLE
Add ScopeFunctions and PropertyFunctions utilities with tests

### DIFF
--- a/core-utils/src/main/kotlin/com/pambrose/common/util/PropertyFunctions.kt
+++ b/core-utils/src/main/kotlin/com/pambrose/common/util/PropertyFunctions.kt
@@ -1,0 +1,44 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.pambrose.common.util
+
+import java.io.File
+
+fun readProperties(vararg fileNames: String) {
+  readProperties(fileNames.toList())
+}
+
+fun readProperties(fileNames: List<String>) {
+  fileNames
+    .map { File(it) }
+    .forEach {
+      if (it.exists())
+        readPropertiesFromFile(it.absolutePath)
+      else
+        error("File not found: ${it.absolutePath}")
+    }
+}
+
+private fun readPropertiesFromFile(fileName: String) {
+  File(fileName)
+    .readLines()
+    .filter { it.contains("=") && !it.startsWith("#") }
+    .forEach { line ->
+      val (key, value) = line.split("=", limit = 2)
+      System.setProperty(key.trim(), value.trim())
+    }
+}

--- a/core-utils/src/main/kotlin/com/pambrose/common/util/ScopeFunctions.kt
+++ b/core-utils/src/main/kotlin/com/pambrose/common/util/ScopeFunctions.kt
@@ -1,0 +1,34 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.pambrose.common.util
+
+/**
+ * Generic two-receiver variant of [with]: executes [block] with both [a] and [b] available as Kotlin
+ * context receivers. Unlike a `vararg` version, the two type parameters keep [a] and [b]'s distinct
+ * types, so each can satisfy a separate `context(...)` parameter (a `vararg` would collapse them to
+ * their common supertype). For more receivers, add further fixed-arity overloads.
+ */
+inline fun <A, B, R> with(
+  a: A,
+  b: B,
+  block: context (A, B) () -> R,
+): R =
+  with(a) {
+    with(b) {
+      block()
+    }
+  }

--- a/core-utils/src/test/kotlin/com/pambrose/util/PropertyFunctionsTests.kt
+++ b/core-utils/src/test/kotlin/com/pambrose/util/PropertyFunctionsTests.kt
@@ -1,0 +1,159 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.pambrose.util
+
+import com.pambrose.common.util.readProperties
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.io.File
+import java.nio.file.Files
+
+// Keys created by these tests are all prefixed with KEY_PREFIX so afterSpec can
+// reliably remove them and avoid leaking state into other specs in the JVM.
+private const val KEY_PREFIX = "com.pambrose.test.propfunc."
+
+private fun writePropsFile(content: String): File =
+  Files
+    .createTempFile("property-functions-test", ".properties")
+    .toFile()
+    .apply {
+      writeText(content)
+      deleteOnExit()
+    }
+
+class PropertyFunctionsTests : StringSpec() {
+  init {
+    afterSpec {
+      System
+        .getProperties()
+        .stringPropertyNames()
+        .filter { name -> name.contains(KEY_PREFIX) }
+        .forEach { name -> System.clearProperty(name) }
+    }
+
+    "readProperties(List) sets system properties from a file" {
+      val file =
+        writePropsFile(
+          """
+          ${KEY_PREFIX}host=localhost
+          ${KEY_PREFIX}port=8080
+          """.trimIndent(),
+        )
+
+      readProperties(listOf(file.absolutePath))
+
+      System.getProperty("${KEY_PREFIX}host") shouldBe "localhost"
+      System.getProperty("${KEY_PREFIX}port") shouldBe "8080"
+    }
+
+    "readProperties(vararg) sets system properties from a file" {
+      val file = writePropsFile("${KEY_PREFIX}vararg=set")
+
+      readProperties(file.absolutePath)
+
+      System.getProperty("${KEY_PREFIX}vararg") shouldBe "set"
+    }
+
+    "readProperties trims whitespace around keys and values" {
+      val file = writePropsFile("   ${KEY_PREFIX}name   =    Paul Ambrose   ")
+
+      readProperties(listOf(file.absolutePath))
+
+      System.getProperty("${KEY_PREFIX}name") shouldBe "Paul Ambrose"
+    }
+
+    "readProperties only splits on the first '=' so values may contain '='" {
+      val url = "jdbc:mysql://host:3306/db?user=admin&ssl=true"
+      val file = writePropsFile("${KEY_PREFIX}url=$url")
+
+      readProperties(listOf(file.absolutePath))
+
+      System.getProperty("${KEY_PREFIX}url") shouldBe url
+    }
+
+    "readProperties supports keys with an empty value" {
+      val file = writePropsFile("${KEY_PREFIX}empty=")
+
+      readProperties(listOf(file.absolutePath))
+
+      System.getProperty("${KEY_PREFIX}empty") shouldBe ""
+    }
+
+    "readProperties skips comment lines starting with '#'" {
+      val file =
+        writePropsFile(
+          """
+          #${KEY_PREFIX}comment=should-not-be-set
+          ${KEY_PREFIX}real=value
+          """.trimIndent(),
+        )
+
+      readProperties(listOf(file.absolutePath))
+
+      System.getProperty("${KEY_PREFIX}comment") shouldBe null
+      System.getProperty("${KEY_PREFIX}real") shouldBe "value"
+    }
+
+    "readProperties skips lines without an '=' separator" {
+      val file =
+        writePropsFile(
+          """
+          this line has no separator
+          ${KEY_PREFIX}kept=yes
+
+          """.trimIndent(),
+        )
+
+      readProperties(listOf(file.absolutePath))
+
+      System.getProperty("${KEY_PREFIX}kept") shouldBe "yes"
+    }
+
+    "readProperties processes every file passed to it" {
+      val first = writePropsFile("${KEY_PREFIX}first=1")
+      val second = writePropsFile("${KEY_PREFIX}second=2")
+
+      readProperties(first.absolutePath, second.absolutePath)
+
+      System.getProperty("${KEY_PREFIX}first") shouldBe "1"
+      System.getProperty("${KEY_PREFIX}second") shouldBe "2"
+    }
+
+    "readProperties throws when a file does not exist" {
+      val missing = File("does-not-exist-${KEY_PREFIX}.properties")
+
+      val exception =
+        shouldThrow<IllegalStateException> {
+          readProperties(listOf(missing.path))
+        }
+      exception.message shouldContain "File not found"
+      exception.message shouldContain missing.absolutePath
+    }
+
+    "readProperties is a no-op when given no files" {
+      shouldNotThrowAny {
+        readProperties()
+        readProperties(emptyList())
+      }
+    }
+  }
+}

--- a/core-utils/src/test/kotlin/com/pambrose/util/ScopeFunctionsTests.kt
+++ b/core-utils/src/test/kotlin/com/pambrose/util/ScopeFunctionsTests.kt
@@ -1,0 +1,58 @@
+/*
+ *   Copyright © 2026 Paul Ambrose (pambrose@mac.com)
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package com.pambrose.util
+
+import com.pambrose.common.util.with
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+// Helpers exercise the context parameters supplied by with(a, b) { ... }.
+// Each is resolved by type, so a and b satisfy separate context(...) parameters.
+
+context(text: String)
+private fun shout(): String = text.uppercase()
+
+context(value: Int)
+private fun doubled(): Int = value * 2
+
+context(prefix: String, repeat: Int)
+private fun render(): String = prefix.repeat(repeat)
+
+class ScopeFunctionsTests : StringSpec() {
+  init {
+    "with makes both values available as context parameters" {
+      with("ab", 3) { render() } shouldBe "ababab"
+    }
+
+    "with resolves each receiver to a separate single-context function by type" {
+      with("hi", 21) { "${shout()}-${doubled()}" } shouldBe "HI-42"
+    }
+
+    "with returns the block result and propagates its type" {
+      val length: Int = with("hello", 4) { shout().length + doubled() }
+      length shouldBe 13
+    }
+
+    "with keeps the two receivers distinct rather than collapsing to a supertype" {
+      // a: String and b: Int share only Any/Comparable as a supertype; a vararg
+      // variant would lose their concrete types and break the calls above.
+      with("Alice", 30) { "${shout()} is ${doubled()}" } shouldBe "ALICE is 60"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds two small Kotlin utilities to `core-utils` along with full test coverage:

- **`ScopeFunctions.kt`** — a two-receiver `with(a, b) { ... }` scope function. Using two type parameters keeps `a` and `b`'s distinct types so each can satisfy a separate `context(...)` parameter (a `vararg` variant would collapse them to a common supertype).
- **`PropertyFunctions.kt`** — `readProperties(...)` helpers (vararg and `List` overloads) that load `key=value` files into system properties, skipping `#` comments and lines without `=`, trimming keys/values, and splitting only on the first `=`.

## Tests

- `ScopeFunctionsTests` — verifies both receivers resolve by type, the block result/type propagates, and the two receivers stay distinct.
- `PropertyFunctionsTests` — covers both overloads, whitespace trimming, `=`-in-value handling, empty values, comment/blank-line skipping, multi-file processing, the missing-file error path, and the no-arg no-op. Uses real temp files and cleans up its system properties in `afterSpec`.

All tests pass; the new code is clean under Kotlinter and Detekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)