### PR TITLE
Enable return-value checker for production code and bump Exposed to 1.3.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,10 @@ import com.vanniktech.maven.publish.SourcesJar
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.extensions.DetektExtension
 import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+import org.gradle.kotlin.dsl.named
 import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.kotlin.jvm) apply false
@@ -96,6 +98,16 @@ fun Project.configureKotlin() {
                 "kotlinx.serialization.ExperimentalSerializationApi",
             ).forEach {
                 languageSettings.optIn(it)
+            }
+        }
+
+        // Run the unused-return-value checker over production code only. Kotest's
+        // assertion DSL (e.g. shouldBe) returns its receiver, and tests intentionally
+        // discard that result, so applying the checker to the test source set would
+        // emit only false-positive warnings.
+        tasks.named<KotlinCompile>("compileKotlin") {
+            compilerOptions {
+                freeCompilerArgs.add("-Xreturn-value-checker=check")
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ ktor = "3.5.1"
 tcnative = "2.0.75.Final"
 
 # Data
-exposed = "1.3.0"
+exposed = "1.3.1"
 h2 = "2.3.232"
 redis = "7.5.2"
 


### PR DESCRIPTION
## Summary

- Enable Kotlin's unused-return-value checker (`-Xreturn-value-checker=check`) on `compileKotlin` only, so production code is analyzed while the test source set is skipped. Kotest's assertion DSL (e.g. `shouldBe`) returns its receiver and tests intentionally discard that result, so running the checker over tests would emit only false-positive warnings.
- Bump Exposed `1.3.0` → `1.3.1`.

## Test plan

- `./gradlew build` compiles cleanly with the new checker enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)