### PR TITLE
Harden dependencyUpdates pre-release filter and clean up configureVersions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
@@ -5,7 +6,7 @@ import com.vanniktech.maven.publish.SourcesJar
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.extensions.DetektExtension
 import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
-import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -80,6 +81,7 @@ subprojects {
     configureDokka()
     configureKover()
     configurePublishing()
+    configureVersions()
 
     rootProject.dependencies.add("dokka", this)
     rootProject.dependencies.add("kover", this)
@@ -199,3 +201,25 @@ fun Project.configurePublishing() {
         }
     }
 }
+
+fun Project.configureVersions() {
+    // A pre-release qualifier is a `.` or `-` delimiter followed by a known unstable
+    // keyword. `m\d` matches milestones (`-M1`/`.M2`) without catching stable classifiers
+    // like `-macos`/`-MR1`, and the `[.-]` delimiter catches both dash-style (`-alpha`)
+    // and dot-style (Netty's `.Beta1`) qualifiers while leaving `-jre`/`.Final` stable.
+    val preReleaseQualifier =
+        Regex("""[.-](rc|beta|alpha|m\d|cr|snapshot|eap|dev|milestone|pre)""", RegexOption.IGNORE_CASE)
+
+    fun isNonStable(version: String): Boolean = preReleaseQualifier.containsMatchIn(version)
+
+    tasks.withType<DependencyUpdatesTask>().configureEach {
+        notCompatibleWithConfigurationCache("the dependency updates plugin is not compatible with the configuration cache")
+        // Reject a pre-release candidate only when the current version is stable. For
+        // dependencies we intentionally track on a pre-release line (e.g. a detekt
+        // alpha), newer pre-releases are still surfaced as available updates.
+        rejectVersionIf {
+            isNonStable(candidate.version) && !isNonStable(currentVersion)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary

Improves the `configureVersions()` helper that filters pre-release versions out of the ben-manes `dependencyUpdates` report. Found via a multi-agent code review of the current branch.

### `isNonStable` correctness

The old denylist (`["-RC", "-BETA", "-ALPHA", "-M"]`) only matched **hyphen-prefixed** qualifiers via unanchored substring, which produced two bugs:

1. **Missed pre-releases → recommended unstable upgrades.** Dot-separated qualifiers (Netty `netty-tcnative` is at `2.0.75.Final`; a `2.0.76.Beta1`/`.CR1` would slip through) and dash tags like `-snapshot`/`-eap`/`-dev` were classified as stable.
2. **Over-matched `-M` → hid stable updates.** The 2-char `-M` token matched any qualifier starting with M (`-macos`, `-MR1`, `-META`), so legitimate stable upgrades were silently dropped.

Both are replaced by a delimiter-anchored regex:

```kotlin
Regex("""[.-](rc|beta|alpha|m\d|cr|snapshot|eap|dev|milestone|pre)""", RegexOption.IGNORE_CASE)
```

`m\d` anchors milestones to a following digit; `[.-]` catches both dash- and dot-style qualifiers; classifier versions like guava's `-jre` and Netty's `.Final` stay stable.

### Cleanup

- Switched to the lazy `tasks.withType<DependencyUpdatesTask>().configureEach { }` form (matching the Detekt block) so the task isn't eagerly realized on every unrelated build.
- Removed two stray IDE auto-imports (a Gradle-internal shaded `PackingUtils.config` and `DokkaDefaults.moduleName`).

The current-aware `rejectVersionIf` behavior (only reject a pre-release candidate when the current version is stable) is unchanged.

## Test plan

- `./gradlew :core-utils:dependencyUpdates --no-parallel` runs cleanly.
- Confirmed detekt pre-releases still surface, while `guava -jre` and `kotlinx-datetime -0.6.x-compat` are correctly treated as stable (no false rejections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)