### PR TITLE
Bump detekt, pambrose-gradle-plugins, and redis

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,9 +4,9 @@ gradle-wrapper = "9.6.1"
 jvmTarget = "17"
 
 # Plugins
-detekt = "2.0.0-alpha.4"
+detekt = "2.0.0-alpha.5"
 dokka = "2.2.0"
-gradlePlugins = "1.0.14"
+gradlePlugins = "1.1.0"
 kover = "0.9.8"
 mavenPublish = "0.37.0"
 versions = "0.54.0"
@@ -33,7 +33,7 @@ tcnative = "2.0.75.Final"
 # Data
 exposed = "1.3.1"
 h2 = "2.3.232"
-redis = "7.5.2"
+redis = "7.5.3"
 
 # Scripting
 javaScripting = "2.0.0"


### PR DESCRIPTION
## Summary

Routine dependency version bumps in the version catalog:

- `detekt` 2.0.0-alpha.4 → 2.0.0-alpha.5
- `gradlePlugins` (pambrose-gradle-plugins) 1.0.14 → 1.1.0
- `redis` 7.5.2 → 7.5.3

## Test plan

- CI build (`./gradlew build`) with the bumped versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)