### PR TITLE
Document the 2.9.3 release and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to Common Utils are documented in this file.
 
+## [2.9.3] - 2026-07-03
+
+### New features
+
+- `with(a, b) { ... }` (core-utils, `ScopeFunctions.kt`): a two-receiver variant of the standard `with` that runs a `context(A, B) () -> R` block with both `a` and `b` available as context parameters. The two type parameters keep each receiver's distinct type, so each can satisfy a separate `context(...)` parameter (a `vararg` would collapse them to their common supertype). For more receivers, add further fixed-arity overloads.
+- `readProperties(vararg fileNames)` / `readProperties(List<String>)` (core-utils, `PropertyFunctions.kt`): load `key=value` lines from the given files into JVM system properties via `System.setProperty`, skipping `#`-comment and non-`key=value` lines and failing fast when a file is missing.
+
+### Build & tooling
+
+- Enable Kotlin's unused-return-value checker (`-Xreturn-value-checker=check`) on the production `compileKotlin` task only; test source sets are skipped so Kotest's assertion DSL (which returns its receiver) does not emit false positives.
+- Replace the `com.pambrose.stable-versions` convention plugin with a direct `com.github.ben-manes.versions` plugin plus an inline `configureVersions()` helper. Its `isNonStable` filter now uses a delimiter-anchored regex that recognizes dot-separated qualifiers (Netty's `.Beta1`, Spring/Hibernate `.RC1`/`.CR1`) while leaving classifier versions such as guava's `-jre` stable, and it rejects a pre-release candidate only when the current version is stable — so dependencies intentionally tracked on a pre-release line (e.g. detekt alphas) still surface updates. The `DependencyUpdatesTask` is now configured lazily via `configureEach`.
+
+### Dependency bumps
+
+- Gradle wrapper 9.5.1 → 9.6.1
+- `detekt` 2.0.0-alpha.4 → 2.0.0-alpha.5
+- `gradlePlugins` (pambrose convention plugins) 1.0.14 → 1.1.0
+- `mavenPublish` 0.36.0 → 0.37.0
+- `grpc` 1.82.0 → 1.82.1
+- `ktor` 3.5.0 → 3.5.1
+- `exposed` 1.3.0 → 1.3.1
+- `redis` 7.5.2 → 7.5.3
+- Bump project version to 2.9.3
+
 ## [2.9.2] - 2026-06-14
 
 ### New features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,16 +71,18 @@ Run `make help` for a self-documenting list of every target.
 
 ### Build Configuration
 
-The root `build.gradle.kts` applies a shared set of plugins to every subproject and defines two inline configuration functions:
+The root `build.gradle.kts` applies a shared set of plugins to every subproject and defines several inline configuration functions, including:
 
 - `configureKotlin()` - JVM 17 target, experimental opt-ins
 - `configurePublishing()` - Maven publication setup (vanniktech maven-publish) and per-module Dokka configuration
+- `configureVersions()` - pre-release filtering for the ben-manes `dependencyUpdates` task
 
-Common behavior for testing, linting, and dependency-update reporting is provided by [`pambrose-gradle-plugins`](https://github.com/pambrose/pambrose-gradle-plugins) convention plugins applied to every subproject:
+Common behavior for testing and linting is provided by [`pambrose-gradle-plugins`](https://github.com/pambrose/pambrose-gradle-plugins) convention plugins applied to every subproject:
 
 - `com.pambrose.testing` - JUnit Platform, `kotest-runner-junit5` and `kotlin-test` as default `testImplementation`, logback-classic on test runtime
 - `com.pambrose.kotlinter` - Kotlinter lint/format tasks
-- `com.pambrose.stable-versions` - stable-only filtering for `dependencyUpdates`
+
+Dependency-update reporting uses the `com.github.ben-manes.versions` plugin, configured by the inline `configureVersions()`: its `isNonStable` filter rejects a pre-release candidate only when the current version is stable, so dependencies intentionally tracked on a pre-release line still surface updates.
 
 Detekt is applied directly in the root `build.gradle.kts` via `configureDetekt()`. The aggregate `detekt` task depends on the per-source-set `detektMain` and `detektTest` tasks, so analysis runs with full type resolution. Optional shared config lives at `config/detekt/detekt.yml` and a shared suppression baseline at `config/detekt/baseline.xml` (both auto-detected if present).
 
@@ -99,7 +101,7 @@ These opt-ins are enabled globally:
 ### Key Technologies
 
 - Kotlin 2.4.0 with JVM target 17
-- Gradle 9.5.1 with Kotlin DSL
+- Gradle 9.6.1 with Kotlin DSL
 - Kotest + MockK for testing
 - Kotlinter for linting
 
@@ -109,6 +111,6 @@ All modules use: `com.pambrose.common.*`
 
 ### Version Management
 
-- Project version: "2.9.2" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
+- Project version: "2.9.3" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
 - Group: "com.pambrose.common-utils" (set in `gradle.properties`)
 - All library versions in `gradle/libs.versions.toml`

--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ dependencies {
 
 ## Technology Stack
 
-- **Languages**: Kotlin 2.3.21, Java
-- **Build System**: Gradle 9.5.0 with Kotlin DSL
+- **Languages**: Kotlin 2.4.0, Java
+- **Build System**: Gradle 9.6.1 with Kotlin DSL
 - **Testing**: Kotest, MockK
 - **Serialization**: Kotlinx.serialization
 - **Concurrency**: Kotlin Coroutines, Guava

--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ This library is available on [Maven Central](https://central.sonatype.com/artifa
 ```kotlin
 dependencies {
     // Include specific modules as needed
-  implementation("com.pambrose.common-utils:core-utils:2.9.2")
-  implementation("com.pambrose.common-utils:json-utils:2.9.2")
-  implementation("com.pambrose.common-utils:ktor-server-utils:2.9.2")
+  implementation("com.pambrose.common-utils:core-utils:2.9.3")
+  implementation("com.pambrose.common-utils:json-utils:2.9.3")
+  implementation("com.pambrose.common-utils:ktor-server-utils:2.9.3")
     // ... other modules
 }
 ```
@@ -212,7 +212,7 @@ dependencies {
     <dependency>
         <groupId>com.pambrose.common-utils</groupId>
         <artifactId>core-utils</artifactId>
-      <version>2.9.2</version>
+      <version>2.9.3</version>
     </dependency>
     <!-- Add other modules as needed -->
 </dependencies>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,29 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
+## v2.9.3 — 2026-07-03
+
+### Highlights
+
+- **New scope & property helpers (core-utils)**: A two-receiver `with(a, b) { ... }` that exposes both arguments as context parameters — each keeping its distinct type, unlike a `vararg` — and `readProperties(...)`, which loads `key=value` files into JVM system properties.
+- **Correct pre-release filtering for `make versions`**: The `dependencyUpdates` stable-version filter moved inline into `configureVersions()` (replacing the `com.pambrose.stable-versions` convention plugin) and now uses a delimiter-anchored regex. It recognizes dot-separated qualifiers like Netty's `.Beta1` while leaving classifier versions such as guava's `-jre` stable, and only rejects a pre-release candidate when the current version is stable — so dependencies intentionally tracked on a pre-release line (e.g. detekt alphas) still surface updates.
+- **Return-value checker on production code**: Kotlin's `-Xreturn-value-checker=check` is enabled for `compileKotlin` (test sources excluded to avoid Kotest DSL false positives).
+
+### Dependency bumps
+
+- Gradle wrapper 9.5.1 → 9.6.1
+- `detekt` 2.0.0-alpha.4 → 2.0.0-alpha.5
+- `gradlePlugins` 1.0.14 → 1.1.0
+- `mavenPublish` 0.36.0 → 0.37.0
+- `grpc` 1.82.0 → 1.82.1
+- `ktor` 3.5.0 → 3.5.1
+- `exposed` 1.3.0 → 1.3.1
+- `redis` 7.5.2 → 7.5.3
+
+**Full Changelog**: https://github.com/pambrose/common-utils/compare/2.9.2...2.9.3
+
+---
+
 ## v2.9.2 — 2026-06-14
 
 ### Highlights

--- a/core-utils/README.md
+++ b/core-utils/README.md
@@ -52,6 +52,11 @@ programming tasks.
 - **Number Extensions**: Mathematical operations and formatting for numbers
 - **Random Utilities**: Secure random number generation
 
+### Scope & Property Functions
+
+- **Two-receiver `with`**: A `with(a, b) { ... }` overload that runs a block with both `a` and `b` in scope as context parameters, each keeping its distinct type
+- **Property Loading**: `readProperties(...)` loads `key=value` files into JVM system properties
+
 ## Usage Examples
 
 ### Atomic Operations
@@ -116,6 +121,29 @@ class MyApp
 
 val version = Version.versionOf<MyApp>()
 println(version.json()) // {"version": "1.0.0", "build_time": "..."}
+```
+
+### Scope Functions
+
+```kotlin
+import com.pambrose.common.util.with
+
+// Two-receiver `with`: both arguments are available as context parameters
+// inside the block, each keeping its own type (unlike a `vararg`).
+with(logger, config) {
+  // context(Logger, Config) is in scope here
+}
+```
+
+### Property Files
+
+```kotlin
+import com.pambrose.common.util.readProperties
+
+// Load `key=value` lines from one or more files into JVM system properties.
+// `#`-comment and non-`key=value` lines are skipped; a missing file fails fast.
+readProperties("app.properties", "secrets.properties")
+val token = System.getProperty("api.token")
 ```
 
 ## Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.pambrose.common-utils
-version=2.9.2
+version=2.9.3
 
 kotlin.code.style=official
 org.gradle.caching=true

--- a/llms.txt
+++ b/llms.txt
@@ -2,14 +2,14 @@
 
 > Modular Kotlin/Java utility libraries providing extension functions, DSLs, and helpers for common frameworks. Each module is independently consumable via Maven Central.
 
-- Version: 2.9.0
+- Version: 2.9.3
 - Group: com.pambrose.common-utils
 - Repository: https://github.com/pambrose/common-utils
 - Maven Central: https://central.sonatype.com/namespace/com.pambrose.common-utils
 - License: Apache 2.0
 - Kotlin: 2.4.0, JVM 17
 - Base package: com.pambrose.common.*
-- Install: `implementation("com.pambrose.common-utils:<module>:2.9.0")`
+- Install: `implementation("com.pambrose.common-utils:<module>:2.9.3")`
 
 
 ## Modules


### PR DESCRIPTION
## Summary

Prepares the 2.9.3 release (dated 2026-07-03).

- Bumps the project version to **2.9.3** in `gradle.properties` and the root README usage examples.
- Adds the 2.9.3 entry to `CHANGELOG.md` and `RELEASE_NOTES.md`.
- Refreshes stale references in `llms.txt` (2.9.0 → 2.9.3), `CLAUDE.md` (ben-manes + `configureVersions()` replacing the removed `stable-versions` convention plugin; Gradle 9.6.1; version 2.9.3), and the root README Technology Stack (Kotlin 2.4.0, Gradle 9.6.1).
- Documents the two new core-utils utilities (`with(a, b)` two-receiver scope function and `readProperties(...)`) in `core-utils/README.md`.

## What's in 2.9.3

Everything merged since 2.9.2 (#141–#145):

### New features
- `with(a, b) { ... }` — two-receiver `with` exposing both args as context parameters (core-utils).
- `readProperties(...)` — load `key=value` files into JVM system properties (core-utils).

### Build & tooling
- Kotlin unused-return-value checker (`-Xreturn-value-checker=check`) on production `compileKotlin` only.
- Replaced the `com.pambrose.stable-versions` convention plugin with a direct ben-manes `versions` plugin + inline `configureVersions()`; the pre-release filter now uses a delimiter-anchored regex and only rejects a pre-release when the current version is stable.

### Dependency bumps
- Gradle wrapper 9.5.1 → 9.6.1, `detekt` alpha.4 → alpha.5, `gradlePlugins` 1.0.14 → 1.1.0, `mavenPublish` 0.36.0 → 0.37.0, `grpc` 1.82.0 → 1.82.1, `ktor` 3.5.0 → 3.5.1, `exposed` 1.3.0 → 1.3.1, `redis` 7.5.2 → 7.5.3.

## Test plan

- Docs-and-version-only change; CI build confirms the version bump is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)