### PR TITLE
Document the 3.0.0 release, fix Dependabot alerts, and harden repository resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ All notable changes to Common Utils are documented in this file.
 
 - `jetty` 12.1.10 → 12.1.11
 - `kotest` 6.2.1 → 6.2.2
+- Security: Yarn resolution overrides force patched versions of vulnerable transitive npm packages in the
+  JS/wasmJs test toolchains — `ws` 8.20.1 → 8.21.0 (memory-exhaustion DoS), `serialize-javascript`
+  6.0.2 → 7.0.5 (RCE + CPU DoS), `diff` 7.0.0 → 8.0.3 (parsePatch DoS) — clearing all five Dependabot
+  alerts on the `kotlin-js-store/` lockfiles. Dev-time test infrastructure only; nothing ships in
+  published artifacts.
 - Bump project version to 3.0.0 (major: the two binary/coordinate deviations above for the KMP modules)
 
 ## [2.9.3] - 2026-07-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ All notable changes to Common Utils are documented in this file.
   Kotlin 2.4 deprecates for removal (https://kotl.in/native-targets-tiers); Apple platforms are covered by the
   Arm64 device/simulator targets.
 - Build: `kmpModuleNames` switch in the root `build.gradle.kts` selects KMP vs JVM configuration;
-  settings repositories mode changed from `FAIL_ON_PROJECT_REPOS` to `PREFER_SETTINGS` with ivy repositories
-  for the Node.js/Yarn/Binaryen toolchain downloads; `kotlin-js-store/` lockfiles are now tracked;
-  Gradle heap raised to 8g for Kotlin/Native link tasks.
+  settings-level ivy repositories serve the Node.js/Yarn/Binaryen toolchain downloads under
+  `FAIL_ON_PROJECT_REPOS` (each toolchain env spec's `downloadBaseUrl` is unset so the Kotlin plugin never
+  registers project-level repositories); `kotlin-js-store/` lockfiles are now tracked; Gradle heap raised
+  to 8g for Kotlin/Native link tasks.
 
 ### Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Common Utils are documented in this file.
 
-## [Unreleased]
+## [3.0.0] - 2026-07-09
 
 ### Kotlin Multiplatform conversion
 
@@ -24,11 +24,6 @@ All notable changes to Common Utils are documented in this file.
 - Tests: portable Kotest specs moved to `commonTest` and now execute on JVM (JUnit Platform), Node.js,
   wasmJs, and native simulators via the Kotest Gradle plugin (`io.kotest` + KSP); JVM-bound specs stay in
   `jvmTest`. watchOS/tvOS simulator test tasks are disabled (no simulator runtimes installed by default).
-- Tests: aggregate JVM instruction coverage raised from 83.5% to 98.1% with new hermetic Kotest specs across
-  grpc-utils (in-process gRPC + TLS-context fixtures), ktor-server-utils (servlet adapters), redis-utils
-  (mocked Jedis incl. `scanKeys`), exposed-utils (H2 in-memory incl. custom `upsert`), guava-utils
-  (monitor/waiter concurrency), recaptcha-utils, email-utils webhooks, script pools, and the core-utils and
-  ktor-client-utils JVM extensions (`blockingGet`, salted hashes).
 - The native target set excludes the Intel-based Apple targets (`macosX64`, `tvosX64`, `watchosX64`), which
   Kotlin 2.4 deprecates for removal (https://kotl.in/native-targets-tiers); Apple platforms are covered by the
   Arm64 device/simulator targets.
@@ -36,6 +31,37 @@ All notable changes to Common Utils are documented in this file.
   settings repositories mode changed from `FAIL_ON_PROJECT_REPOS` to `PREFER_SETTINGS` with ivy repositories
   for the Node.js/Yarn/Binaryen toolchain downloads; `kotlin-js-store/` lockfiles are now tracked;
   Gradle heap raised to 8g for Kotlin/Native link tasks.
+
+### Testing
+
+- Aggregate JVM instruction coverage raised from 83.5% to 98.7%; the remaining misses are almost entirely
+  unreachable defensive branches. Coverage of the core-utils and ktor-client-utils JVM extensions
+  (`blockingGet` against a loopback HTTP server, salted hashes with known-answer vectors) closes the
+  codecov patch findings from the multiplatform conversion.
+- `RecaptchaService`'s verification `HttpClient` is now an internal, swappable property, giving tests a seam
+  to fake Google's siteverify endpoint with a MockEngine-backed client; new tests cover the verification
+  success/failure response branches, the outgoing form parameters, and `RecaptchaResponse`'s serializer
+  write path. Production behavior and the public API are unchanged.
+- New hermetic specs across the JVM modules: in-process gRPC round-trip and TLS-context construction from
+  committed self-signed PEM fixtures (grpc-utils), MockK-based servlet adapter and Jedis tests
+  (ktor-server-utils, redis-utils), H2 in-memory Exposed tests including the custom `upsert`
+  (exposed-utils), latch-handshake concurrency tests (guava-utils), webhook serialization branches
+  (email-utils), and Jython pool lifecycle (script-utils-python).
+
+### Build & tooling
+
+- Aggregate `detekt`/`detektBaseline` tasks are wired with `tasks.named()` instead of a name-matching live
+  spec; the kotlinter lint/format generated-source excludes collapsed onto the shared
+  `ConfigurableKtLintTask` supertype with the excluded path derived from `layout.buildDirectory`
+  (separator-safe); watchOS/tvOS simulator test disabling selects targets by `konanTarget.family` instead of
+  task-name prefixes; duplicated publishing jar arguments and the `-Xreturn-value-checker` flag hoisted to
+  shared values.
+
+### Dependency bumps
+
+- `jetty` 12.1.10 → 12.1.11
+- `kotest` 6.2.1 → 6.2.2
+- Bump project version to 3.0.0 (major: the two binary/coordinate deviations above for the KMP modules)
 
 ## [2.9.3] - 2026-07-03
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,12 +131,22 @@ These opt-ins are enabled globally:
 - watchOS/tvOS simulator test tasks are disabled (host Xcode lacks those simulator runtimes); Apple coverage
   comes from macOS and iOS simulator test tasks.
 
+### Testing Notes
+
+- All tests are hermetic: no network, no external services. gRPC tests use the in-process transport and
+  committed self-signed PEM fixtures (`grpc-utils/src/test/resources/tls/`); Exposed tests use in-memory H2;
+  Redis tests mock Jedis with MockK; `blockingGet` tests run against a loopback JDK `HttpServer`.
+- `RecaptchaService.httpClient` is `internal` (not private) as a test seam: module tests swap in a
+  MockEngine-backed client to fake Google's siteverify endpoint, restoring the original in a `finally`.
+- Demo `main()` functions in guava-utils concurrent classes are excluded from coverage via
+  `koverExcludeClasses` in the root build script; don't write tests for them.
+
 ### Package Structure
 
 All modules use: `com.pambrose.common.*`
 
 ### Version Management
 
-- Project version: "2.9.3" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
+- Project version: "3.0.0" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
 - Group: "com.pambrose.common-utils" (set in `gradle.properties`)
 - All library versions in `gradle/libs.versions.toml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,9 @@ These opt-ins are enabled globally:
 
 - `kotlin-js-store/` holds the Node/Yarn lockfiles for the JS and wasmJs toolchains; commit changes to it
   (run `./gradlew kotlinUpgradeYarnLock kotlinWasmUpgradeYarnLock` when JS dependencies change).
-- `settings.gradle.kts` uses `PREFER_SETTINGS` repositories mode with ivy repositories for the Node.js, Yarn,
-  and Binaryen distributions.
+- `settings.gradle.kts` uses `FAIL_ON_PROJECT_REPOS` repositories mode with ivy repositories for the Node.js,
+  Yarn, and Binaryen distributions; the root build script unsets every toolchain env spec's `downloadBaseUrl`
+  (root and per-subproject) so the Kotlin plugin never registers project-level repositories.
 - The mixed common/JVM files (`StringExtensions`, `MiscExtensions`, `MiscFuncs` in core-utils) are split across
   `commonMain` and `jvmMain` using `@file:JvmName` + `@file:JvmMultifileClass` so the compiled JVM facade classes
   (and therefore the published JVM ABI) are unchanged.

--- a/README.md
+++ b/README.md
@@ -204,21 +204,25 @@ This library is available on [Maven Central](https://central.sonatype.com/artifa
 ```kotlin
 dependencies {
     // Include specific modules as needed
-  implementation("com.pambrose.common-utils:core-utils:2.9.3")
-  implementation("com.pambrose.common-utils:json-utils:2.9.3")
-  implementation("com.pambrose.common-utils:ktor-server-utils:2.9.3")
+  implementation("com.pambrose.common-utils:core-utils:3.0.0")
+  implementation("com.pambrose.common-utils:json-utils:3.0.0")
+  implementation("com.pambrose.common-utils:ktor-server-utils:3.0.0")
     // ... other modules
 }
 ```
 
 ### Maven
 
+For the multiplatform modules (**core-utils**, **json-utils**, **ktor-client-utils**), Maven consumers must
+depend on the `-jvm` artifact (e.g. `core-utils-jvm`); Gradle consumers resolve the correct variant from the
+root coordinate automatically. The JVM-only modules keep their plain artifact ids.
+
 ```xml
 <dependencies>
     <dependency>
         <groupId>com.pambrose.common-utils</groupId>
-        <artifactId>core-utils</artifactId>
-      <version>2.9.3</version>
+        <artifactId>core-utils-jvm</artifactId>
+      <version>3.0.0</version>
     </dependency>
     <!-- Add other modules as needed -->
 </dependencies>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,32 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
+## v3.0.0 — 2026-07-09
+
+### Highlights
+
+- **Kotlin Multiplatform (core-utils, json-utils, ktor-client-utils)**: The three modules are now KMP, targeting JVM, JS, wasmJs, and Native (iOS/macOS/tvOS/watchOS/Linux/Windows). Portable code moved to `commonMain` and JVM-bound code to `jvmMain`, keeping the published JVM API unchanged; the mixed files are split with `@file:JvmName` + `@file:JvmMultifileClass` so the compiled JVM facade classes stay binary-identical. The remaining 16 framework modules stay Kotlin/JVM and consume core-utils' jvm variant transparently. The Intel-based Apple targets (`macosX64`, `tvosX64`, `watchosX64`), which Kotlin 2.4 deprecates for removal, are not published; Apple platforms are covered by the Arm64 device/simulator targets.
+- **Why 3.0.0 (breaking changes)**: Non-Gradle (Maven) consumers of the three KMP modules must now depend on the `-jvm` artifact (e.g. `core-utils-jvm`); Gradle consumers resolve the correct variant from the root coordinate automatically. `KtorDsl.blockingGet(...)` became a JVM-only extension function — qualified call sites compile unchanged, but the compiled symbol moved from `KtorDsl` to `KtorDslJvmKt` (binary-incompatible for this one function), and member-import call sites must switch to `import com.pambrose.common.dsl.blockingGet`.
+- **Test coverage**: Aggregate JVM instruction coverage raised from 83.5% to 98.7% with new hermetic Kotest specs across every module — in-process gRPC and TLS-context fixtures, mocked-Jedis Redis tests, H2 in-memory Exposed tests (including the custom `upsert`), servlet adapter and concurrency-waiter tests, and an injectable HTTP client seam in `RecaptchaService` so verification responses are testable without network access.
+- Portable Kotest specs now execute on every host-runnable target (JVM, Node.js for js/wasmJs, and macOS/iOS simulators) via the Kotest Gradle plugin.
+
+### Build & tooling
+
+- Build-script cleanups: aggregate detekt tasks wired via `tasks.named()`, kotlinter excludes unified on the
+  `ConfigurableKtLintTask` supertype with the excluded path derived from the build directory, watchOS/tvOS
+  simulator test disabling keyed on `konanTarget.family`, and shared publishing/compiler-flag values hoisted.
+- Settings repositories switched to `PREFER_SETTINGS` with ivy repositories for the Node.js/Yarn/Binaryen
+  toolchains; `kotlin-js-store/` lockfiles are now tracked.
+
+### Dependency bumps
+
+- `jetty` 12.1.10 → 12.1.11
+- `kotest` 6.2.1 → 6.2.2
+
+**Full Changelog**: https://github.com/pambrose/common-utils/compare/2.9.3...3.0.0
+
+---
+
 ## v2.9.3 — 2026-07-03
 
 ### Highlights

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,8 +19,9 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 - Build-script cleanups: aggregate detekt tasks wired via `tasks.named()`, kotlinter excludes unified on the
   `ConfigurableKtLintTask` supertype with the excluded path derived from the build directory, watchOS/tvOS
   simulator test disabling keyed on `konanTarget.family`, and shared publishing/compiler-flag values hoisted.
-- Settings repositories switched to `PREFER_SETTINGS` with ivy repositories for the Node.js/Yarn/Binaryen
-  toolchains; `kotlin-js-store/` lockfiles are now tracked.
+- Node.js/Yarn/Binaryen toolchain distributions resolve from settings-level ivy repositories under
+  `FAIL_ON_PROJECT_REPOS` (toolchain `downloadBaseUrl`s are unset, so the Kotlin plugin registers no
+  project-level repositories); `kotlin-js-store/` lockfiles are now tracked.
 
 ### Dependency bumps
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,8 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 - `jetty` 12.1.10 → 12.1.11
 - `kotest` 6.2.1 → 6.2.2
+- Security (npm test toolchain): Yarn resolutions force `ws` 8.21.0, `serialize-javascript` 7.0.5, and
+  `diff` 8.0.3, clearing all five Dependabot alerts on the JS/wasmJs lockfiles (dev-time only).
 
 **Full Changelog**: https://github.com/pambrose/common-utils/compare/2.9.3...3.0.0
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,10 @@ import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
+import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
+import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension
+import org.jetbrains.kotlin.gradle.targets.wasm.yarn.WasmYarnPlugin
+import org.jetbrains.kotlin.gradle.targets.wasm.yarn.WasmYarnRootExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.konan.target.Family
 import org.jmailen.gradle.kotlinter.KotlinterExtension
@@ -81,6 +85,28 @@ kover {
                 classes(koverExcludeClasses)
             }
         }
+    }
+}
+
+// Force patched versions of vulnerable transitive npm packages in the JS/wasmJs test
+// toolchains (Dependabot: ws DoS, serialize-javascript RCE/DoS, jsdiff DoS). The toolchain
+// requests them with pins/ranges that cannot reach the fixed versions on their own. After
+// changing these, re-run `./gradlew kotlinUpgradeYarnLock kotlinWasmUpgradeYarnLock`.
+val yarnResolutions = mapOf(
+    "ws" to "8.21.0",
+    "serialize-javascript" to "7.0.5",
+    "diff" to "8.0.3",
+)
+
+plugins.withType<YarnPlugin> {
+    the<YarnRootExtension>().apply {
+        yarnResolutions.forEach { (pkg, version) -> resolution(pkg, version) }
+    }
+}
+
+plugins.withType<WasmYarnPlugin> {
+    the<WasmYarnRootExtension>().apply {
+        yarnResolutions.forEach { (pkg, version) -> resolution(pkg, version) }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinJvm
@@ -15,9 +17,19 @@ import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsEnvSpec
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
+import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootEnvSpec
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension
+import org.jetbrains.kotlin.gradle.targets.wasm.binaryen.BinaryenEnvSpec
+import org.jetbrains.kotlin.gradle.targets.wasm.binaryen.BinaryenPlugin
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsEnvSpec
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsPlugin
+import org.jetbrains.kotlin.gradle.targets.wasm.nodejs.WasmNodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.wasm.yarn.WasmYarnPlugin
+import org.jetbrains.kotlin.gradle.targets.wasm.yarn.WasmYarnRootEnvSpec
 import org.jetbrains.kotlin.gradle.targets.wasm.yarn.WasmYarnRootExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.konan.target.Family
@@ -98,13 +110,47 @@ val yarnResolutions = mapOf(
     "diff" to "8.0.3",
 )
 
+// The settings script declares ivy repositories for the Node.js/Yarn/Binaryen distributions
+// and uses FAIL_ON_PROJECT_REPOS; unsetting each toolchain env spec's downloadBaseUrl stops
+// the Kotlin plugin registering equivalent project-level repositories (which that mode would
+// reject). Clear the convention too — set(null) alone falls back to it.
+fun Property<String>.unsetDownloadBaseUrl() {
+    convention(null as String?)
+    set(null as String?)
+}
+
+plugins.withType<NodeJsRootPlugin> {
+    the<NodeJsEnvSpec>().downloadBaseUrl.unsetDownloadBaseUrl()
+}
+
+plugins.withType<WasmNodeJsRootPlugin> {
+    the<WasmNodeJsEnvSpec>().downloadBaseUrl.unsetDownloadBaseUrl()
+}
+
+plugins.withType<BinaryenPlugin> {
+    the<BinaryenEnvSpec>().downloadBaseUrl.unsetDownloadBaseUrl()
+}
+
+// The per-project NodeJs plugins register their own env spec (and distribution repository)
+// on each subproject with a JS or wasmJs target, so the root-level unset does not cover them.
+subprojects {
+    plugins.withType<NodeJsPlugin> {
+        the<NodeJsEnvSpec>().downloadBaseUrl.unsetDownloadBaseUrl()
+    }
+    plugins.withType<WasmNodeJsPlugin> {
+        the<WasmNodeJsEnvSpec>().downloadBaseUrl.unsetDownloadBaseUrl()
+    }
+}
+
 plugins.withType<YarnPlugin> {
+    the<YarnRootEnvSpec>().downloadBaseUrl.unsetDownloadBaseUrl()
     the<YarnRootExtension>().apply {
         yarnResolutions.forEach { (pkg, version) -> resolution(pkg, version) }
     }
 }
 
 plugins.withType<WasmYarnPlugin> {
+    the<WasmYarnRootEnvSpec>().downloadBaseUrl.unsetDownloadBaseUrl()
     the<WasmYarnRootExtension>().apply {
         yarnResolutions.forEach { (pkg, version) -> resolution(pkg, version) }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.pambrose.common-utils
-version=2.9.3
+version=3.0.0
 
 kotlin.code.style=official
 kotlin.native.ignoreDisabledTargets=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ logging = "8.0.4"
 dropwizard = "4.2.39"
 grpc = "1.82.1"
 jakartaServlet = "6.1.0"
-jetty = "12.1.10"
+jetty = "12.1.11"
 ktor = "3.5.1"
 # Keep in sync with grpc
 tcnative = "2.0.75.Final"
@@ -54,7 +54,7 @@ guava = "33.0.0-jre"
 resend = "4.13.0"
 
 # Testing
-kotest = "6.2.1"
+kotest = "6.2.2"
 # KSP versions independently of Kotlin since 2.3.0 (required by the kotest plugin)
 ksp = "2.3.9"
 mockk = "1.14.9"

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -7,7 +7,17 @@
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
   integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
 
-ws@8.20.1:
-  version "8.20.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+diff@8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
+  integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
+
+serialize-javascript@7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
+  integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
+
+ws@8.20.1, ws@8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -135,10 +135,10 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
-diff@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
-  integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
+diff@8.0.3, diff@^7.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
+  integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -372,13 +372,6 @@ picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
-
 readdirp@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
@@ -389,17 +382,10 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
-safe-buffer@^5.1.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.0.5, serialize-javascript@^6.0.2:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
+  integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -537,10 +523,10 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
-ws@8.20.1:
-  version "8.20.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@8.20.1, ws@8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/llms.txt
+++ b/llms.txt
@@ -2,26 +2,30 @@
 
 > Modular Kotlin/Java utility libraries providing extension functions, DSLs, and helpers for common frameworks. Each module is independently consumable via Maven Central.
 
-- Version: 2.9.3
+- Version: 3.0.0
 - Group: com.pambrose.common-utils
 - Repository: https://github.com/pambrose/common-utils
 - Maven Central: https://central.sonatype.com/namespace/com.pambrose.common-utils
 - License: Apache 2.0
 - Kotlin: 2.4.0, JVM 17
 - Base package: com.pambrose.common.*
-- Install: `implementation("com.pambrose.common-utils:<module>:2.9.3")`
+- Install: `implementation("com.pambrose.common-utils:<module>:3.0.0")`
+- Multiplatform: core-utils, json-utils, and ktor-client-utils are Kotlin Multiplatform (JVM, JS, wasmJs,
+  Native — iOS/macOS/tvOS/watchOS/Linux/Windows); all other modules are JVM-only
+- Maven (non-Gradle) consumers of the three multiplatform modules must use the `-jvm` artifact
+  (e.g. `core-utils-jvm`); Gradle resolves the correct variant from the root coordinate
 
 
 ## Modules
 
 Use core-utils for general Kotlin/Java utility needs. Other modules target specific frameworks — pick only what you need.
 
-- [core-utils](core-utils/README.md): General-purpose Kotlin extensions and helpers. Use for string/number/collection operations, I/O, atomic delegates, time/duration helpers, reflection, version management. No framework dependencies. Foundation for most other modules.
-- [json-utils](json-utils/README.md): Kotlinx.serialization helpers. Use for JsonElement navigation (dot-notation paths), type-safe extraction, format configs (pretty/raw/lenient/strict). Depends on: core-utils.
+- [core-utils](core-utils/README.md): General-purpose Kotlin extensions and helpers (multiplatform). Use for string/number/collection operations, I/O, atomic delegates, time/duration helpers, reflection, version management. No framework dependencies. Foundation for most other modules.
+- [json-utils](json-utils/README.md): Kotlinx.serialization helpers (multiplatform). Use for JsonElement navigation (dot-notation paths), type-safe extraction, format configs (pretty/raw/lenient/strict). Depends on: core-utils.
 - [exposed-utils](exposed-utils/README.md): JetBrains Exposed SQL extensions. Use for custom SQL expressions, UPSERT, timed transactions, ResultRow helpers. Standalone.
 - [redis-utils](redis-utils/README.md): Jedis client extensions. Use for Redis connection management and common operation patterns. Depends on: core-utils.
 - [ktor-server-utils](ktor-server-utils/README.md): Ktor server extensions. Use for Heroku HTTPS redirect, response utilities, servlet integration. Depends on: core-utils.
-- [ktor-client-utils](ktor-client-utils/README.md): Ktor HTTP client DSL. Use for client configuration and request/response utilities. Depends on: core-utils.
+- [ktor-client-utils](ktor-client-utils/README.md): Ktor HTTP client DSL (multiplatform; `blockingGet` is JVM-only). Use for client configuration and request/response utilities. Depends on: core-utils.
 - [jetty-utils](jetty-utils/README.md): Jetty 12 (EE11) server DSL. Use for server config, lambda-based servlets (Jakarta Servlet 6.1), version endpoints. Depends on: core-utils.
 - [grpc-utils](grpc-utils/README.md): gRPC channel/server DSL. Use for TLS/SSL setup, server lifecycle, StreamObserver helpers. Standalone.
 - [dropwizard-utils](dropwizard-utils/README.md): Dropwizard Metrics DSL. Use for metric definitions, health checks, JMX integration. Standalone.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-import org.gradle.api.initialization.resolve.RepositoriesMode.PREFER_SETTINGS
+import org.gradle.api.initialization.resolve.RepositoriesMode.FAIL_ON_PROJECT_REPOS
 
 pluginManagement {
     repositories {
@@ -12,11 +12,11 @@ plugins {
 }
 
 dependencyResolutionManagement {
-    // PREFER_SETTINGS rather than FAIL_ON_PROJECT_REPOS: the Kotlin JS/Wasm toolchain
-    // registers its distribution repositories at the project level, which the FAIL
-    // mode turns into an error. PREFER_SETTINGS ignores those and resolves everything
-    // from the repositories declared here.
-    repositoriesMode.set(PREFER_SETTINGS)
+    // The Kotlin JS/Wasm toolchain would register its distribution repositories at the
+    // project level, which this mode turns into an error; the root build script unsets
+    // each toolchain env spec's downloadBaseUrl so those repositories are never added,
+    // and the ivy repositories declared below serve the distributions instead.
+    repositoriesMode.set(FAIL_ON_PROJECT_REPOS)
     repositories {
         mavenCentral()
 


### PR DESCRIPTION
## Summary

Prepares the 3.0.0 release and clears the security/build-hygiene items that surfaced after the KMP conversion merged. Three commits:

### Document the 3.0.0 release and bump version
- Version 2.9.3 → **3.0.0** in `gradle.properties` (major: Maven consumers of the three KMP modules must switch to the `-jvm` artifact, and `KtorDsl.blockingGet` moved to `KtorDslJvmKt`).
- CHANGELOG's Unreleased section becomes `[3.0.0] - 2026-07-09`, with new Testing (coverage 83.5% → 98.7%, RecaptchaService test seam), Build & tooling, and Dependency bumps sections.
- RELEASE_NOTES v3.0.0 entry with highlights and an explicit "why 3.0.0" breaking-changes note.
- README's Maven example fixed to `core-utils-jvm` with the `-jvm` artifact rule explained; llms.txt and CLAUDE.md updated to match.
- Dependency bumps: `jetty` 12.1.10 → 12.1.11, `kotest` 6.2.1 → 6.2.2.

### Force patched npm packages in the JS/wasmJs test toolchains
Clears all five Dependabot alerts on the `kotlin-js-store/` lockfiles via Yarn resolution overrides (the toolchain's pins/ranges could never reach the fixes on their own):
- `ws` 8.20.1 → 8.21.0 (GHSA-96hv-2xvq-fx4p, memory-exhaustion DoS)
- `serialize-javascript` 6.0.2 → 7.0.5 (GHSA-5c6j-r48x-rmvq RCE; CVE-2026-34043 CPU DoS)
- `diff` 7.0.0 → 8.0.3 (CVE-2026-24001 parsePatch DoS)

Dev-time test-runner dependencies only; nothing from these lockfiles ships in published artifacts.

### Restore FAIL_ON_PROJECT_REPOS and stop toolchain repo registration
- Settings repositories mode goes back from `PREFER_SETTINGS` to the strict `FAIL_ON_PROJECT_REPOS` guardrail; future project-level repository declarations fail loudly instead of being silently ignored.
- Every Kotlin JS/wasm toolchain env spec's `downloadBaseUrl` is unset (root and per-subproject) so the plugin never registers project-level distribution repositories — eliminating the repeated "repository was added by unknown code" warnings at their source. The settings-level ivy repositories keep serving the Node.js/Yarn/Binaryen downloads.

## Verification

- `./gradlew build -x test -x allTests` completes with zero repository warnings under the strict mode.
- `kotlinUpgradeYarnLock` / `kotlinWasmUpgradeYarnLock` regenerate cleanly; both lockfiles pin the patched npm versions; `jsNodeTest` and `wasmJsNodeTest` pass against the patched toolchain (mocha's `diff` 7→8 and `serialize-javascript` 6→7 jumps verified benign).
- `:email-utils:test` and `:jetty-utils:test` smoke-tested the kotest 6.2.2 / jetty 12.1.11 bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)