### PR TITLE
Add multiplatform DateUtils object with zone-neutral date/time helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to Common Utils are documented in this file.
 
+## [Unreleased]
+
+### New features
+
+- New `DateUtils` object (core-utils, `DateUtils.kt`) collecting multiplatform date/time helpers built on
+  `kotlinx-datetime`: ISO parsing (`parseToLocalDate`/`parseToLocalTime`/`parseToLocalDateTime`),
+  `instantNow`/`localDateNow`/`localDateTimeNow`, US-style formatters (`toMMDDYYYY`, `toMMDDYY`, `toMMDD`,
+  `toDashedYYYYMMDD`, `toFullDateString`, `toLogString`, `toMMDDYYYYHHMM`, `toCreated`, `toISO8601`,
+  `toUTCDateTime`), `abbrevDayOfWeek`, and duration/age helpers (`age`, `toAdjustedString`). Every member is
+  KDoc-documented.
+- `DateUtils` is time-zone-neutral: `localDateNow`/`localDateTimeNow` default to
+  `TimeZone.currentSystemDefault()` instead of a hardcoded region, and no named zone is resolved internally,
+  so core-utils pulls no IANA time-zone database into JS/wasmJs consumers. Callers needing a fixed zone pass
+  one explicitly (which on JS/wasmJs requires the `@js-joda/timezone` npm package on the consumer side).
+- **Moved (source-incompatible)**: `toFullDateString` and `abbrevDayOfWeek`, previously top-level functions in
+  `com.pambrose.common.util`, are now members of the `DateUtils` object; update call sites to
+  `import com.pambrose.common.util.DateUtils.toFullDateString` (and `.abbrevDayOfWeek`).
+
+### Bug fixes
+
+- `DateUtils.toFullDateString` no longer appends a hardcoded `"PST"` suffix, which was incorrect during
+  Pacific Daylight Time.
+- `DateUtils.toLogString` left-pads the millisecond field, so `5 ms` renders as `.005` (previously `.500`).
+- `DateUtils.toMMDDYYYYHHMM` zero-pads the hour, so 9 AM renders as `09:05` (previously `9:05`).
+
+### Build & tooling
+
+- KMP module `Test` tasks configure `testLogging` (PASSED/SKIPPED/FAILED events with full exception format).
+
+### Dependency bumps
+
+- `logback` 1.5.32 → 1.5.38
+- `grpc` 1.82.1 → 1.82.2
+
 ## [3.0.0] - 2026-07-09
 
 ### Kotlin Multiplatform conversion

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,10 @@ These opt-ins are enabled globally:
   (and therefore the published JVM ABI) are unchanged.
 - watchOS/tvOS simulator test tasks are disabled (host Xcode lacks those simulator runtimes); Apple coverage
   comes from macOS and iOS simulator test tasks.
+- core-utils bundles no IANA time-zone database: `DateUtils` resolves only `TimeZone.currentSystemDefault()`
+  and UTC, so named zones (which need the `@js-joda/timezone` npm package on JS/wasm) stay a consumer
+  concern. Keep new common code zone-neutral to preserve this — a hardcoded named zone would force the tz
+  database into every JS/wasmJs consumer.
 
 ### Testing Notes
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/pambrose/common-utils)](https://github.com/pambrose/common-utils/releases)
 [![Maven Central](https://img.shields.io/maven-central/v/com.pambrose.common-utils/core-utils)](https://central.sonatype.com/artifact/com.pambrose.common-utils/core-utils)
 [![Tests](https://github.com/pambrose/common-utils/actions/workflows/test.yml/badge.svg)](https://github.com/pambrose/common-utils/actions/workflows/test.yml)
-[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.21-red?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin version](https://img.shields.io/badge/kotlin-2.4.0-red?logo=kotlin)](http://kotlinlang.org)
 [![ktlint](https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081)](https://pinterest.github.io/ktlint/)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/5bb4750894844031a55375227acfff6f)](https://app.codacy.com/gh/pambrose/common-utils/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![codecov](https://codecov.io/gh/pambrose/common-utils/branch/master/graph/badge.svg)](https://codecov.io/gh/pambrose/common-utils)
@@ -34,7 +34,7 @@ Fundamental utility functions and extensions for common programming tasks.
 - String, number, and collection utilities
 - I/O operations with security enhancements
 - Atomic operations and thread-safe delegates
-- Time duration helpers
+- Date/time formatting and duration helpers (`DateUtils`), zone-neutral by default
 - Reflection utilities
 
 ### Framework Integration

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,26 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
+## Unreleased
+
+### Highlights
+
+- **New `DateUtils` object (core-utils)**: multiplatform date/time parsing, US-style formatting, and
+  duration/age helpers built on kotlinx-datetime, with KDoc on every member. `localDateNow`/
+  `localDateTimeNow` default to the system time zone rather than a hardcoded region, so core-utils bundles no
+  IANA time-zone database into JS/wasmJs consumers; callers needing a fixed zone pass one explicitly.
+- **Moved (source-incompatible)**: `toFullDateString` and `abbrevDayOfWeek` are now members of `DateUtils`
+  rather than top-level `com.pambrose.common.util` functions — update the corresponding member imports.
+- **Formatter fixes**: `toFullDateString` drops the misleading hardcoded `PST` label; `toLogString` left-pads
+  milliseconds (`.005`, not `.500`); `toMMDDYYYYHHMM` zero-pads the hour.
+
+### Dependency bumps
+
+- `logback` 1.5.32 → 1.5.38
+- `grpc` 1.82.1 → 1.82.2
+
+---
+
 ## v3.0.0 — 2026-07-09
 
 ### Highlights

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,8 @@ import dev.detekt.gradle.extensions.DetektExtension
 import io.kotest.framework.gradle.KotestGradleExtension
 import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
 import org.gradle.api.tasks.testing.AbstractTestTask
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
@@ -290,6 +292,11 @@ fun Project.configureKotlinMultiplatform() {
     // The com.pambrose.testing convention plugin does this for the JVM modules.
     tasks.withType<Test>().configureEach {
         useJUnitPlatform()
+        testLogging {
+            events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR)
+            exceptionFormat = TestExceptionFormat.FULL
+            showStandardStreams = false
+        }
     }
 
     // Kotest discovers commonTest specs on the non-JVM targets too, but a target whose

--- a/core-utils/src/commonMain/kotlin/com/pambrose/common/util/DateUtils.kt
+++ b/core-utils/src/commonMain/kotlin/com/pambrose/common/util/DateUtils.kt
@@ -1,0 +1,249 @@
+package com.pambrose.common.util
+
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.TimeZone.Companion.UTC
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.number
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.todayIn
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlin.time.DurationUnit.DAYS
+import kotlin.time.DurationUnit.HOURS
+import kotlin.time.DurationUnit.MILLISECONDS
+import kotlin.time.DurationUnit.MINUTES
+import kotlin.time.DurationUnit.SECONDS
+import kotlin.time.Instant
+
+/**
+ * Date/time parsing, formatting, and arithmetic helpers shared across all Kotlin targets.
+ *
+ * Formatters render US-style `MM/DD` dates; the `*Now` helpers default to the system time zone
+ * rather than assuming a region. Declared as an `object` so its extensions are brought in by
+ * member import (e.g. `import com.pambrose.common.util.DateUtils.toMMDDYY`).
+ */
+object DateUtils {
+  /**
+   * Parses this ISO-8601 date string (e.g. `"2024-03-15"`) into a [LocalDate].
+   *
+   * Extension function on [String].
+   *
+   * @return the parsed [LocalDate]
+   * @throws IllegalArgumentException if the text is not a valid ISO-8601 date
+   */
+  fun String.parseToLocalDate() = LocalDate.Formats.ISO.parse(this)
+
+  /**
+   * Parses this ISO-8601 time string (e.g. `"13:45:30"`) into a [LocalTime].
+   *
+   * Extension function on [String].
+   *
+   * @return the parsed [LocalTime]
+   * @throws IllegalArgumentException if the text is not a valid ISO-8601 time
+   */
+  fun String.parseToLocalTime() = LocalTime.Formats.ISO.parse(this)
+
+  /**
+   * Parses this ISO-8601 date-time string (e.g. `"2024-03-15T08:30:45"`) into a [LocalDateTime].
+   *
+   * Extension function on [String].
+   *
+   * @return the parsed [LocalDateTime]
+   * @throws IllegalArgumentException if the text is not a valid ISO-8601 date-time
+   */
+  fun String.parseToLocalDateTime() = LocalDateTime.Formats.ISO.parse(this)
+
+  /** Returns the current moment from the system clock as an [Instant]. */
+  fun instantNow(): Instant = Clock.System.now()
+
+  /**
+   * The current date in [timeZone] (the system default zone unless specified).
+   *
+   * The default avoids assuming a specific region; callers that need a fixed zone should pass one
+   * (e.g. `TimeZone.of("America/Los_Angeles")`). Note that resolving a named zone on Kotlin/JS and
+   * wasmJs requires the `@js-joda/timezone` npm package, which those consumers must add themselves.
+   */
+  fun localDateNow(timeZone: TimeZone = TimeZone.currentSystemDefault()): LocalDate = Clock.System.todayIn(timeZone)
+
+  /**
+   * The current date-time in [timeZone] (the system default zone unless specified).
+   *
+   * See [localDateNow] for the note on named zones under Kotlin/JS and wasmJs.
+   */
+  fun localDateTimeNow(timeZone: TimeZone = TimeZone.currentSystemDefault()): LocalDateTime =
+    instantNow().toLocalDateTime(timeZone)
+
+  /**
+   * Returns the last minute of this [LocalDate] in UTC, i.e. `23:59:00.001` of the same day.
+   *
+   * Useful as an inclusive end-of-day boundary. Extension function on [LocalDate].
+   *
+   * @return the date at `23:59:00.001` UTC as a [LocalDateTime]
+   */
+  fun LocalDate.toUTCDateTime(): LocalDateTime =
+    atStartOfDayIn(UTC)
+      .plus(1.days)
+      .minus(1.minutes)
+      .plus(1.milliseconds)
+      .toLocalDateTime(UTC)
+
+  /**
+   * Formats this [LocalDateTime] as an ISO-8601 string with a trailing `Z`, dropping any
+   * fractional-seconds component (e.g. `2024-03-15T08:30:45.123` becomes `"2024-03-15T08:30:45Z"`).
+   *
+   * The `Z` labels the value as UTC; no zone conversion is performed. Extension function on
+   * [LocalDateTime].
+   *
+   * @return the ISO-8601 string
+   */
+  fun LocalDateTime.toISO8601(): String =
+    toString().let { str ->
+      (if (str.contains(".")) str.substringBefore(".") else str) + "Z"
+    }
+
+  /** Returns the three-letter, title-cased abbreviation of this [DayOfWeek] (e.g. `"Mon"`). */
+  private fun DayOfWeek.abbrev(): String = name.lowercase().capitalizeFirstChar().substring(0, 3)
+
+  /**
+   * Returns the abbreviated day-of-week name (e.g., `"Mon"`, `"Tue"`).
+   *
+   * Extension function on [LocalDate].
+   */
+  fun LocalDate.abbrevDayOfWeek(): String = dayOfWeek.abbrev()
+
+  /**
+   * Returns the abbreviated day-of-week name (e.g., `"Mon"`, `"Tue"`).
+   *
+   * Extension function on [LocalDateTime].
+   */
+  fun LocalDateTime.abbrevDayOfWeek(): String = dayOfWeek.abbrev()
+
+  /**
+   * Formats this [LocalDateTime] as a full date string, e.g., `"Mon 04/10/26 14:30:00"`.
+   *
+   * Extension function on [LocalDateTime].
+   *
+   * @return the formatted date/time string
+   */
+  fun LocalDateTime.toFullDateString(): String =
+    "${abbrevDayOfWeek()} ${month.number.lpad(2)}/${day.lpad(2)}/${(year - 2000).lpad(2)} " +
+      "${hour.lpad(2)}:${minute.lpad(2)}:${second.lpad(2)}"
+
+  /**
+   * Formats this [LocalDateTime] as a log-friendly timestamp with milliseconds, e.g.
+   * `"04/10/26 14:30:45.123"` (`MM/DD/YY HH:MM:SS.mmm`).
+   *
+   * Extension function on [LocalDateTime].
+   *
+   * @return the formatted timestamp string
+   */
+  fun LocalDateTime.toLogString(): String =
+    "${month.number.lpad(2)}/${day.lpad(2)}/${(year - 2000).lpad(2)} ${hour.lpad(2)}:${
+      minute.lpad(2)
+    }:${second.lpad(2)}.${(nanosecond / 1000000).lpad(3)}"
+
+  /**
+   * Formats this [LocalDate] as `MM/DD/YYYY`, e.g. `"04/10/2026"`.
+   *
+   * Extension function on [LocalDate].
+   *
+   * @return the formatted date string
+   */
+  fun LocalDate.toMMDDYYYY(): String = "${month.number.lpad(2)}/${day.lpad(2)}/${year.lpad(4)}"
+
+  /**
+   * Formats this [LocalDate] as `MM/DD/YY` (two-digit year), e.g. `"04/10/26"`.
+   *
+   * Extension function on [LocalDate].
+   *
+   * @return the formatted date string
+   */
+  fun LocalDate.toMMDDYY(): String = "${month.number.lpad(2)}/${day.lpad(2)}/${(year - 2000).lpad(2)}"
+
+  /**
+   * Formats this [LocalDate] as `MM/DD`, e.g. `"04/10"`.
+   *
+   * Extension function on [LocalDate].
+   *
+   * @return the formatted date string
+   */
+  fun LocalDate.toMMDD(): String = "${month.number.lpad(2)}/${day.lpad(2)}"
+
+  /**
+   * Formats this [LocalDate] as ISO-style `YYYY-MM-DD`, e.g. `"2026-04-10"`.
+   *
+   * Extension function on [LocalDate].
+   *
+   * @return the formatted date string
+   */
+  fun LocalDate.toDashedYYYYMMDD(): String = "${year.lpad(4)}-${month.number.lpad(2)}-${day.lpad(2)}"
+
+  /**
+   * Formats this [LocalDateTime] as `MM/DD/YYYY HH:MM`, e.g. `"04/10/2026 14:30"`.
+   *
+   * Extension function on [LocalDateTime].
+   *
+   * @return the formatted date/time string
+   */
+  fun LocalDateTime.toMMDDYYYYHHMM(): String =
+    "${month.number.lpad(2)}/${day.lpad(2)}/${year.lpad(4)} ${hour.lpad(2)}:${minute.lpad(2)}"
+
+  /**
+   * Wraps [toMMDDYYYYHHMM] in a `"(Created …)"` label, e.g. `"(Created 04/10/2026 14:30)"`.
+   *
+   * Extension function on [LocalDateTime].
+   *
+   * @return the parenthesized "created" string
+   */
+  fun LocalDateTime.toCreated(): String = "(Created ${toMMDDYYYYHHMM()})"
+
+  /**
+   * The elapsed [Duration] from this instant until now, or [Duration.ZERO] if the receiver is null.
+   *
+   * Extension property on a nullable [Instant].
+   */
+  val Instant?.age get() = if (this != null) instantNow() - this else Duration.ZERO
+
+  /**
+   * The elapsed [Duration] from this date-time until now, interpreting the receiver in [timeZone],
+   * or [Duration.ZERO] if the receiver is null.
+   *
+   * Extension function on a nullable [LocalDateTime].
+   *
+   * @param timeZone the zone used to convert this local date-time to an [Instant]
+   * @return the age, or [Duration.ZERO] when the receiver is null
+   */
+  fun LocalDateTime?.age(timeZone: TimeZone): Duration = this?.toInstant(timeZone)?.age ?: Duration.ZERO
+
+  /**
+   * Truncates this [Duration] down to whole [unit]s and returns its [Duration.toString] form.
+   *
+   * For example, `95.seconds.toAdjustedString(MINUTES)` is `"1m"` while `95.seconds.toAdjustedString()`
+   * (the default [DurationUnit.SECONDS]) is `"1m 35s"`.
+   *
+   * @param unit the coarsest unit to retain; defaults to [DurationUnit.SECONDS]
+   * @return the truncated duration formatted by [Duration.toString]
+   * @throws IllegalStateException if [unit] is finer than [DurationUnit.MILLISECONDS]
+   *   (i.e. microseconds or nanoseconds)
+   */
+  fun Duration.toAdjustedString(unit: DurationUnit = SECONDS): String =
+    when (unit) {
+      MILLISECONDS -> inWholeMilliseconds.milliseconds
+      SECONDS -> inWholeSeconds.seconds
+      MINUTES -> inWholeMinutes.minutes
+      HOURS -> inWholeHours.hours
+      DAYS -> inWholeDays.days
+      else -> error("Unsupported duration unit: $unit")
+    }.toString()
+}

--- a/core-utils/src/commonMain/kotlin/com/pambrose/common/util/DateUtils.kt
+++ b/core-utils/src/commonMain/kotlin/com/pambrose/common/util/DateUtils.kt
@@ -112,7 +112,6 @@ object DateUtils {
       (if (str.contains(".")) str.substringBefore(".") else str) + "Z"
     }
 
-  /** Returns the three-letter, title-cased abbreviation of this [DayOfWeek] (e.g. `"Mon"`). */
   private fun DayOfWeek.abbrev(): String = name.lowercase().capitalizeFirstChar().substring(0, 3)
 
   /**

--- a/core-utils/src/commonMain/kotlin/com/pambrose/common/util/MiscFuncs.kt
+++ b/core-utils/src/commonMain/kotlin/com/pambrose/common/util/MiscFuncs.kt
@@ -22,8 +22,6 @@ package com.pambrose.common.util
 import kotlin.contracts.contract
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.number
 
 /**
  * Returns `true` if this value is not null, with a Kotlin contract that smart-casts the receiver.
@@ -48,17 +46,6 @@ fun Any?.isNull(): Boolean {
   }
   return this == null
 }
-
-/**
- * Formats this [LocalDateTime] as a full date string, e.g., `"Mon 04/10/26 14:30:00 PST"`.
- *
- * Extension function on [LocalDateTime].
- *
- * @return the formatted date/time string
- */
-fun LocalDateTime.toFullDateString(): String =
-  "${abbrevDayOfWeek()} ${month.number.lpad(2)}/${day.lpad(2)}/${(year - 2000).lpad(2)} " +
-    "${hour.lpad(2)}:${minute.lpad(2)}:${second.lpad(2)} PST"
 
 /**
  * Left-pads this [Int] to the specified [width] with [padChar].
@@ -87,13 +74,6 @@ fun Int.rpad(
   width: Int,
   padChar: Char = '0',
 ): String = toString().padEnd(width, padChar)
-
-/**
- * Returns the abbreviated day-of-week name (e.g., `"Mon"`, `"Tue"`).
- *
- * Extension function on [LocalDateTime].
- */
-fun LocalDateTime.abbrevDayOfWeek(): String = dayOfWeek.name.lowercase().capitalizeFirstChar().substring(0, 3)
 
 /**
  * Capitalizes the first character of this [String].

--- a/core-utils/src/commonTest/kotlin/com/pambrose/util/DateUtilsTest.kt
+++ b/core-utils/src/commonTest/kotlin/com/pambrose/util/DateUtilsTest.kt
@@ -1,0 +1,180 @@
+package com.pambrose.util
+
+import com.pambrose.common.util.DateUtils.abbrevDayOfWeek
+import com.pambrose.common.util.DateUtils.age
+import com.pambrose.common.util.DateUtils.parseToLocalDate
+import com.pambrose.common.util.DateUtils.parseToLocalDateTime
+import com.pambrose.common.util.DateUtils.parseToLocalTime
+import com.pambrose.common.util.DateUtils.toAdjustedString
+import com.pambrose.common.util.DateUtils.toCreated
+import com.pambrose.common.util.DateUtils.toDashedYYYYMMDD
+import com.pambrose.common.util.DateUtils.toFullDateString
+import com.pambrose.common.util.DateUtils.toISO8601
+import com.pambrose.common.util.DateUtils.toLogString
+import com.pambrose.common.util.DateUtils.toMMDD
+import com.pambrose.common.util.DateUtils.toMMDDYY
+import com.pambrose.common.util.DateUtils.toMMDDYYYY
+import com.pambrose.common.util.DateUtils.toMMDDYYYYHHMM
+import com.pambrose.common.util.DateUtils.toUTCDateTime
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldHaveLength
+import io.kotest.matchers.string.shouldNotContain
+import kotlinx.datetime.IllegalTimeZoneException
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlin.time.Instant
+
+class DateUtilsTest : StringSpec() {
+  init {
+    "parseToLocalDate - parses ISO date" {
+      "2024-03-15".parseToLocalDate() shouldBe LocalDate(2024, 3, 15)
+    }
+
+    "parseToLocalTime - parses ISO time" {
+      "13:45:30".parseToLocalTime() shouldBe LocalTime(13, 45, 30)
+    }
+
+    "parseToLocalDateTime - parses ISO date-time" {
+      "2024-03-15T08:30:45".parseToLocalDateTime() shouldBe
+        LocalDateTime(2024, 3, 15, 8, 30, 45)
+    }
+
+    "toUTCDateTime - sets time to 23:59:00.001 of the same UTC day" {
+      val date = LocalDate(2024, 6, 1)
+      val utcDateTime = date.toUTCDateTime()
+      // start-of-day + 1 day - 1 minute + 1 ms = 23:59:00.001 of the same day
+      utcDateTime shouldBe LocalDateTime(2024, 6, 1, 23, 59, 0, 1_000_000)
+    }
+
+    "toISO8601 - appends Z and trims fractional seconds" {
+      LocalDateTime(2024, 3, 15, 8, 30, 45).toISO8601() shouldBe "2024-03-15T08:30:45Z"
+    }
+
+    "toISO8601 - removes nanos when present" {
+      LocalDateTime(2024, 3, 15, 8, 30, 45, 123_000_000).toISO8601() shouldBe "2024-03-15T08:30:45Z"
+    }
+
+    "abbrevDayOfWeek - LocalDate produces 3-letter capitalized day" {
+      // 2024-01-08 is a Monday
+      LocalDate(2024, 1, 8).abbrevDayOfWeek() shouldBe "Mon"
+      LocalDate(2024, 1, 13).abbrevDayOfWeek() shouldBe "Sat"
+
+      // 2026-04-29 is a Wednesday.
+      val wed = LocalDateTime.parse("2026-04-29T10:00:00")
+      wed.abbrevDayOfWeek() shouldHaveLength 3
+      wed.abbrevDayOfWeek() shouldBe "Wed"
+    }
+
+    "abbrevDayOfWeek - LocalDateTime produces 3-letter capitalized day" {
+      LocalDateTime(2024, 1, 10, 0, 0).abbrevDayOfWeek() shouldBe "Wed"
+    }
+
+    "toFullDateString - includes day, mm/dd/yy and time without a hardcoded zone label" {
+      val ldt = LocalDateTime(2024, 3, 7, 9, 5, 7)
+      ldt.toFullDateString() shouldBe "Thu 03/07/24 09:05:07"
+      // The misleading hardcoded "PST" label (wrong during PDT) must no longer be emitted
+      ldt.toFullDateString() shouldNotContain "PST"
+    }
+
+    "toLogString - includes mm/dd/yy time and ms without a hardcoded zone label" {
+      // 12 ms is left-padded to a 3-digit millisecond field: "012"
+      val ldt = LocalDateTime(2024, 3, 7, 9, 5, 7, 12_000_000)
+      ldt.toLogString() shouldBe "03/07/24 09:05:07.012"
+      ldt.toLogString() shouldNotContain "PST"
+    }
+
+    "toLogString - left-pads a single-digit millisecond value" {
+      LocalDateTime(2024, 3, 7, 9, 5, 7, 5_000_000).toLogString() shouldBe "03/07/24 09:05:07.005"
+    }
+
+    "toLogString - keeps a three-digit millisecond value unpadded" {
+      LocalDateTime(2024, 3, 7, 9, 5, 7, 123_000_000).toLogString() shouldBe "03/07/24 09:05:07.123"
+    }
+
+    "toLogString - renders a zero millisecond value as 000" {
+      LocalDateTime(2024, 3, 7, 9, 5, 7, 0).toLogString() shouldBe "03/07/24 09:05:07.000"
+    }
+
+    "toMMDDYYYY - formats year as 4 digits" {
+      LocalDate(2024, 1, 5).toMMDDYYYY() shouldBe "01/05/2024"
+    }
+
+    "toMMDDYY - formats year as 2 digits" {
+      LocalDate(2024, 12, 31).toMMDDYY() shouldBe "12/31/24"
+    }
+
+    "toMMDD - omits year" {
+      LocalDate(2024, 7, 4).toMMDD() shouldBe "07/04"
+    }
+
+    "toDashedYYYYMMDD - SQL-friendly format" {
+      LocalDate(2024, 9, 8).toDashedYYYYMMDD() shouldBe "2024-09-08"
+    }
+
+    "toMMDDYYYYHHMM - includes hour and minute" {
+      LocalDateTime(2024, 5, 1, 14, 7).toMMDDYYYYHHMM() shouldBe "05/01/2024 14:07"
+    }
+
+    "toMMDDYYYYHHMM - zero-pads a single-digit hour" {
+      LocalDateTime(2024, 5, 1, 9, 5).toMMDDYYYYHHMM() shouldBe "05/01/2024 09:05"
+    }
+
+    "toCreated - wraps formatted date in (Created ...)" {
+      val ldt = LocalDateTime(2024, 5, 1, 14, 7)
+      ldt.toCreated() shouldBe "(Created 05/01/2024 14:07)"
+    }
+
+    "Instant.age - returns ZERO for null" {
+      val nullInstant: Instant? = null
+      nullInstant.age shouldBe Duration.ZERO
+    }
+
+    "Instant.age - returns positive duration for past instant" {
+      val past = Clock.System.now() - 5.seconds
+      val age = past.age
+      (age >= 5.seconds) shouldBe true
+    }
+
+    "LocalDateTime.age - returns ZERO for null" {
+      val nullDateTime: LocalDateTime? = null
+      nullDateTime.age(TimeZone.UTC) shouldBe Duration.ZERO
+    }
+
+    "toAdjustedString - truncates duration to specified unit" {
+      val d = 1.hours + 30.minutes + 45.seconds + 250.milliseconds
+      d.toAdjustedString(DurationUnit.SECONDS) shouldEndWith "s"
+      d.toAdjustedString(DurationUnit.MINUTES) shouldBe (1.hours + 30.minutes).toString()
+      d.toAdjustedString(DurationUnit.HOURS) shouldBe 1.hours.toString()
+      d.toAdjustedString(DurationUnit.MILLISECONDS) shouldBe d.inWholeMilliseconds.milliseconds.toString()
+    }
+
+    "toAdjustedString - DAYS unit produces day-rounded string" {
+      val d = 49.hours
+      d.toAdjustedString(DurationUnit.DAYS) shouldBe 2L.let { Duration.parse("2d") }.toString()
+    }
+
+    "toAdjustedString - unsupported unit throws" {
+      shouldThrow<IllegalStateException> {
+        2.hours.toAdjustedString(DurationUnit.NANOSECONDS)
+      }
+    }
+
+    "TimeZone.of with bogus zone throws" {
+      // Sanity for parse safety guards
+      shouldThrow<IllegalTimeZoneException> { TimeZone.of("Not/AZone") }
+    }
+  }
+}

--- a/core-utils/src/jvmMain/kotlin/com/pambrose/common/util/Version.kt
+++ b/core-utils/src/jvmMain/kotlin/com/pambrose/common/util/Version.kt
@@ -16,6 +16,7 @@
 
 package com.pambrose.common.util
 
+import com.pambrose.common.util.DateUtils.toFullDateString
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 import kotlin.time.Instant.Companion.fromEpochMilliseconds

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/MiscFuncsTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/MiscFuncsTests.kt
@@ -18,7 +18,6 @@
 
 package com.pambrose.util
 
-import com.pambrose.common.util.abbrevDayOfWeek
 import com.pambrose.common.util.capitalizeFirstChar
 import com.pambrose.common.util.captureStdout
 import com.pambrose.common.util.hostInfo
@@ -29,7 +28,6 @@ import com.pambrose.common.util.randomId
 import com.pambrose.common.util.repeatWithSleep
 import com.pambrose.common.util.rpad
 import com.pambrose.common.util.sleep
-import com.pambrose.common.util.toFullDateString
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
@@ -150,18 +148,6 @@ class MiscFuncsTests : StringSpec() {
         captureStdout { error("boom") }
       }
       System.out shouldBe originalOut
-    }
-
-    "abbrevDayOfWeek returns 3-char capitalized day name" {
-      // 2026-04-29 is a Wednesday.
-      val wed = LocalDateTime.parse("2026-04-29T10:00:00")
-      wed.abbrevDayOfWeek() shouldHaveLength 3
-      wed.abbrevDayOfWeek() shouldBe "Wed"
-    }
-
-    "toFullDateString formats a date as 'Day MM/DD/YY HH:MM:SS PST'" {
-      val ldt = LocalDateTime.parse("2026-04-29T13:05:09")
-      ldt.toFullDateString() shouldBe "Wed 04/29/26 13:05:09 PST"
     }
   }
 }

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/VersionTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/VersionTests.kt
@@ -50,7 +50,8 @@ class VersionTests : StringSpec() {
 
     "buildString() returns formatted timestamp when annotated" {
       val s = Annotated::class.buildString()
-      s shouldContain "PST"
+      // buildTime is fixed, so toFullDateString is deterministic in the America/Los_Angeles zone.
+      s shouldContain "Sun 03/31/24 17:00:00"
     }
 
     "buildString() returns Unknown when annotation is missing" {

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -84,7 +84,6 @@ coverage has been significantly expanded with **53 test files** across 18 module
 | `StringExtensions.trimEnds()`     | Could throw if `len*2 > string.length`   |
 | `StringExtensions.linesBetween()` | Returns empty list if patterns not found |
 | `NumberExtensions.random()`       | Throws if called with 0 or negative      |
-| `MiscFuncs.toFullDateString()`    | Hardcoded "PST" doesn't account for DST  |
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,12 +20,12 @@ kotlinxHtml = "0.12.0"
 serialization = "1.11.0"
 
 # Logging
-logback = "1.5.32"
+logback = "1.5.38"
 logging = "8.0.4"
 
 # Frameworks
 dropwizard = "4.2.39"
-grpc = "1.82.1"
+grpc = "1.82.2"
 jakartaServlet = "6.1.0"
 jetty = "12.1.11"
 ktor = "3.5.1"

--- a/llms.txt
+++ b/llms.txt
@@ -20,7 +20,7 @@
 
 Use core-utils for general Kotlin/Java utility needs. Other modules target specific frameworks — pick only what you need.
 
-- [core-utils](core-utils/README.md): General-purpose Kotlin extensions and helpers (multiplatform). Use for string/number/collection operations, I/O, atomic delegates, time/duration helpers, reflection, version management. No framework dependencies. Foundation for most other modules.
+- [core-utils](core-utils/README.md): General-purpose Kotlin extensions and helpers (multiplatform). Use for string/number/collection operations, I/O, atomic delegates, date/time formatting and duration helpers (DateUtils; zone-neutral, no bundled tz database), reflection, version management. No framework dependencies. Foundation for most other modules.
 - [json-utils](json-utils/README.md): Kotlinx.serialization helpers (multiplatform). Use for JsonElement navigation (dot-notation paths), type-safe extraction, format configs (pretty/raw/lenient/strict). Depends on: core-utils.
 - [exposed-utils](exposed-utils/README.md): JetBrains Exposed SQL extensions. Use for custom SQL expressions, UPSERT, timed transactions, ResultRow helpers. Standalone.
 - [redis-utils](redis-utils/README.md): Jedis client extensions. Use for Redis connection management and common operation patterns. Depends on: core-utils.


### PR DESCRIPTION
## Summary

Introduces a new `DateUtils` object in **core-utils** (`commonMain`) that consolidates the date/time parsing, formatting, and arithmetic helpers into one place, built on `kotlinx-datetime` and documented with KDoc on every member.

### Zone-neutral by design
`localDateNow` / `localDateTimeNow` default to `TimeZone.currentSystemDefault()` instead of a hardcoded region, and no named zone is resolved internally — so core-utils pulls **no IANA time-zone database** into JS/wasmJs consumers. Callers needing a fixed zone pass one explicitly (which, on JS/wasmJs, requires the `@js-joda/timezone` npm package on the consumer side).

### Moved (source-incompatible)
`toFullDateString` and `abbrevDayOfWeek` move from the top-level `com.pambrose.common.util` (`MiscFuncs`) facade into the `DateUtils` object — update call sites to `import com.pambrose.common.util.DateUtils.toFullDateString` (and `.abbrevDayOfWeek`). The two `abbrevDayOfWeek` overloads are deduplicated onto a shared `DayOfWeek.abbrev()` helper.

## Bug fixes (each with dedicated regression tests)

- `toFullDateString` no longer appends a hardcoded `"PST"` suffix, which was wrong during Pacific Daylight Time.
- `toLogString` left-pads the millisecond field: `5 ms` renders `.005` (previously `.500`).
- `toMMDDYYYYHHMM` zero-pads the hour: 9 AM renders `09:05` (previously `9:05`).

## Build & tooling

- KMP `Test` tasks configure `testLogging` (PASSED/SKIPPED/FAILED events, full exception format).

## Dependency bumps

- `logback` 1.5.32 → 1.5.38
- `grpc` 1.82.1 → 1.82.2

## Docs

Documented under `[Unreleased]` in CHANGELOG and RELEASE_NOTES; noted the zone-neutral constraint in CLAUDE.md; mentioned `DateUtils` in README and llms.txt; removed the now-fixed hardcoded-PST edge case from `docs/CODE_REVIEW.md`.

## Verification

`:core-utils:jvmTest` and `:core-utils:jsNodeTest` (DateUtils logic on JVM + JS), `:grpc-utils:test` (the grpc bump), and `:core-utils:lintKotlin` / `:core-utils:detekt` all pass. The full multiplatform suite (JVM/JS/wasmJs/macOS/iOS) was exercised during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)