### PR TITLE
Add zone-aware toFullDateString overload and bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Common Utils are documented in this file.
 
-## [Unreleased]
+## [3.1.0] - 2026-07-10
 
 ### New features
 
@@ -19,6 +19,11 @@ All notable changes to Common Utils are documented in this file.
 - **Moved (source-incompatible)**: `toFullDateString` and `abbrevDayOfWeek`, previously top-level functions in
   `com.pambrose.common.util`, are now members of the `DateUtils` object; update call sites to
   `import com.pambrose.common.util.DateUtils.toFullDateString` (and `.abbrevDayOfWeek`).
+- `DateUtils.toFullDateString(timeZone)` overload appends the DST-aware UTC offset for the given zone
+  (e.g. `"Mon 04/10/26 14:30:00 -04:00"`, `Z` for a zero offset). kotlinx-datetime exposes the numeric
+  offset rather than a letter abbreviation such as `EST`/`EDT`, which is ambiguous across regions; the
+  no-argument `toFullDateString()` is unchanged. Resolving a named zone on JS/wasmJs still requires the
+  consumer to add `@js-joda/timezone`; fixed-offset and UTC zones need no database.
 
 ### Bug fixes
 
@@ -35,6 +40,7 @@ All notable changes to Common Utils are documented in this file.
 
 - `logback` 1.5.32 → 1.5.38
 - `grpc` 1.82.1 → 1.82.2
+- Bump project version to 3.1.0
 
 ## [3.0.0] - 2026-07-09
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,6 @@ All modules use: `com.pambrose.common.*`
 
 ### Version Management
 
-- Project version: "3.0.0" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
+- Project version: "3.1.0" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
 - Group: "com.pambrose.common-utils" (set in `gradle.properties`)
 - All library versions in `gradle/libs.versions.toml`

--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ This library is available on [Maven Central](https://central.sonatype.com/artifa
 ```kotlin
 dependencies {
     // Include specific modules as needed
-  implementation("com.pambrose.common-utils:core-utils:3.0.0")
-  implementation("com.pambrose.common-utils:json-utils:3.0.0")
-  implementation("com.pambrose.common-utils:ktor-server-utils:3.0.0")
+  implementation("com.pambrose.common-utils:core-utils:3.1.0")
+  implementation("com.pambrose.common-utils:json-utils:3.1.0")
+  implementation("com.pambrose.common-utils:ktor-server-utils:3.1.0")
     // ... other modules
 }
 ```
@@ -222,7 +222,7 @@ root coordinate automatically. The JVM-only modules keep their plain artifact id
     <dependency>
         <groupId>com.pambrose.common-utils</groupId>
         <artifactId>core-utils-jvm</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0</version>
     </dependency>
     <!-- Add other modules as needed -->
 </dependencies>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
-## Unreleased
+## v3.1.0 — 2026-07-10
 
 ### Highlights
 
@@ -17,11 +17,16 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
   rather than top-level `com.pambrose.common.util` functions — update the corresponding member imports.
 - **Formatter fixes**: `toFullDateString` drops the misleading hardcoded `PST` label; `toLogString` left-pads
   milliseconds (`.005`, not `.500`); `toMMDDYYYYHHMM` zero-pads the hour.
+- **Zone-aware formatting**: a new `toFullDateString(timeZone)` overload appends the DST-aware UTC offset
+  (e.g. `-04:00`, or `Z` for zero) — the numeric offset rather than an ambiguous letter abbreviation like
+  `EST`/`EDT`; the no-argument overload is unchanged.
 
 ### Dependency bumps
 
 - `logback` 1.5.32 → 1.5.38
 - `grpc` 1.82.1 → 1.82.2
+
+**Full Changelog**: https://github.com/pambrose/common-utils/compare/3.0.0...3.1.0
 
 ---
 

--- a/core-utils/src/commonMain/kotlin/com/pambrose/common/util/DateUtils.kt
+++ b/core-utils/src/commonMain/kotlin/com/pambrose/common/util/DateUtils.kt
@@ -8,6 +8,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.TimeZone.Companion.UTC
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.number
+import kotlinx.datetime.offsetIn
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.todayIn
@@ -138,6 +139,25 @@ object DateUtils {
   fun LocalDateTime.toFullDateString(): String =
     "${abbrevDayOfWeek()} ${month.number.lpad(2)}/${day.lpad(2)}/${(year - 2000).lpad(2)} " +
       "${hour.lpad(2)}:${minute.lpad(2)}:${second.lpad(2)}"
+
+  /**
+   * Formats this [LocalDateTime] as a full date string suffixed with the UTC offset for [timeZone],
+   * e.g., `"Mon 04/10/26 14:30:00 -04:00"` (a zero offset renders as `"Z"`).
+   *
+   * The receiver is interpreted as a wall-clock time in [timeZone], so the offset reflects daylight
+   * saving where applicable — the same wall-clock time yields `-05:00` in winter and `-04:00` in summer
+   * for an eastern-US zone. kotlinx-datetime exposes the numeric offset rather than a letter
+   * abbreviation such as `EST`/`EDT`, which is ambiguous across regions. Resolving a named zone on
+   * Kotlin/JS and wasmJs requires the `@js-joda/timezone` npm package on the consumer side; fixed-offset
+   * and UTC zones need no database.
+   *
+   * Extension function on [LocalDateTime].
+   *
+   * @param timeZone the zone used to resolve the offset
+   * @return the formatted date/time string with a trailing UTC offset
+   */
+  fun LocalDateTime.toFullDateString(timeZone: TimeZone): String =
+    "${toFullDateString()} ${toInstant(timeZone).offsetIn(timeZone)}"
 
   /**
    * Formats this [LocalDateTime] as a log-friendly timestamp with milliseconds, e.g.

--- a/core-utils/src/commonTest/kotlin/com/pambrose/util/DateUtilsTest.kt
+++ b/core-utils/src/commonTest/kotlin/com/pambrose/util/DateUtilsTest.kt
@@ -28,6 +28,8 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.UtcOffset
+import kotlinx.datetime.asTimeZone
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -87,6 +89,16 @@ class DateUtilsTest : StringSpec() {
       ldt.toFullDateString() shouldBe "Thu 03/07/24 09:05:07"
       // The misleading hardcoded "PST" label (wrong during PDT) must no longer be emitted
       ldt.toFullDateString() shouldNotContain "PST"
+    }
+
+    "toFullDateString(timeZone) - appends the fixed UTC offset" {
+      val ldt = LocalDateTime(2024, 3, 7, 9, 5, 7)
+      ldt.toFullDateString(UtcOffset(hours = -4).asTimeZone()) shouldBe "${ldt.toFullDateString()} -04:00"
+    }
+
+    "toFullDateString(timeZone) - renders a zero offset as Z" {
+      val ldt = LocalDateTime(2024, 3, 7, 9, 5, 7)
+      ldt.toFullDateString(TimeZone.UTC) shouldBe "${ldt.toFullDateString()} Z"
     }
 
     "toLogString - includes mm/dd/yy time and ms without a hardcoded zone label" {

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/DateUtilsJvmTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/DateUtilsJvmTests.kt
@@ -1,0 +1,24 @@
+package com.pambrose.util
+
+import com.pambrose.common.util.DateUtils.toFullDateString
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.string.shouldEndWith
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+
+// Named-zone (IANA) behavior is JVM-only here: java.time ships the tz database, whereas commonTest
+// runs on JS/wasmJs where named zones would need @js-joda/timezone. These verify that the offset
+// appended by toFullDateString(timeZone) is DST-aware for a real zone.
+class DateUtilsJvmTests : StringSpec() {
+  init {
+    "toFullDateString(timeZone) reflects standard time (EST, -05:00) in winter" {
+      val newYork = TimeZone.of("America/New_York")
+      LocalDateTime(2026, 1, 15, 9, 0, 0).toFullDateString(newYork) shouldEndWith " -05:00"
+    }
+
+    "toFullDateString(timeZone) reflects daylight time (EDT, -04:00) in summer" {
+      val newYork = TimeZone.of("America/New_York")
+      LocalDateTime(2026, 7, 15, 9, 0, 0).toFullDateString(newYork) shouldEndWith " -04:00"
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.pambrose.common-utils
-version=3.0.0
+version=3.1.0
 
 kotlin.code.style=official
 kotlin.native.ignoreDisabledTargets=true

--- a/llms.txt
+++ b/llms.txt
@@ -2,14 +2,14 @@
 
 > Modular Kotlin/Java utility libraries providing extension functions, DSLs, and helpers for common frameworks. Each module is independently consumable via Maven Central.
 
-- Version: 3.0.0
+- Version: 3.1.0
 - Group: com.pambrose.common-utils
 - Repository: https://github.com/pambrose/common-utils
 - Maven Central: https://central.sonatype.com/namespace/com.pambrose.common-utils
 - License: Apache 2.0
 - Kotlin: 2.4.0, JVM 17
 - Base package: com.pambrose.common.*
-- Install: `implementation("com.pambrose.common-utils:<module>:3.0.0")`
+- Install: `implementation("com.pambrose.common-utils:<module>:3.1.0")`
 - Multiplatform: core-utils, json-utils, and ktor-client-utils are Kotlin Multiplatform (JVM, JS, wasmJs,
   Native — iOS/macOS/tvOS/watchOS/Linux/Windows); all other modules are JVM-only
 - Maven (non-Gradle) consumers of the three multiplatform modules must use the `-jvm` artifact


### PR DESCRIPTION
## Summary

Two cohesive changes: a new zone-aware `DateUtils.toFullDateString` overload, and the 3.1.0 version bump that ships it (along with the already-merged DateUtils work).

### Zone-aware formatting
Adds `fun LocalDateTime.toFullDateString(timeZone: TimeZone)`, which appends the **DST-aware UTC offset** for the given zone:

```kotlin
LocalDateTime(2026, 7, 15, 9, 0, 0).toFullDateString(TimeZone.of("America/New_York"))
// "… 09:00:00 -04:00"  (EDT; the same wall-clock in January yields -05:00)
```

`kotlinx-datetime` exposes the numeric offset rather than a letter abbreviation like `EST`/`EDT` (which is ambiguous across regions — `CST` is US Central *and* China Standard), so this reports `-04:00` / `Z`. The no-argument `toFullDateString()` is unchanged, and no new dependency is added.

### Version 3.1.0
Bumps `gradle.properties` 3.0.0 → 3.1.0 and finalizes the `[3.1.0]` docs (CHANGELOG, RELEASE_NOTES) covering the new `DateUtils` object, its zone-neutral defaults, the formatter bug fixes, and this overload — plus version references in README, llms.txt, and CLAUDE.md.

## Tests

- **commonTest** (portable — fixed-offset and UTC zones need no tz database, so they run on JS/wasmJs too): a `-04:00` fixed offset appends correctly, and `TimeZone.UTC` renders `Z`.
- **jvmTest** (`DateUtilsJvmTests`, JVM-only since named IANA zones need java.time's database): `America/New_York` gives `-05:00` in January and `-04:00` in July, proving the offset tracks DST.

## Verification

`:core-utils:jvmTest`, `:core-utils:jsNodeTest` (confirms the portable cases run without `IllegalTimeZoneException`), `:core-utils:lintKotlin`, and `:core-utils:detekt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)