### PR TITLE
Document the 3.2.0 release and bump Kotlin to 2.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Common Utils are documented in this file.
 
+## [3.2.0] - 2026-07-14
+
+### Build & tooling
+
+- Silence the deprecated `io.grpc.Attributes.keys()` warning in the grpc-utils test suite with a scoped
+  `@Suppress("DEPRECATION")`. gRPC exposes no public replacement for enumerating attribute keys
+  (`keysForTest()` is package-private), so the test's exact-key-set assertion is preserved rather than
+  dropped. Test-only — no API or behavior change.
+
+### Dependency bumps
+
+- `kotlin` 2.4.0 → 2.4.10
+- Bump project version to 3.2.0
+
 ## [3.1.0] - 2026-07-10
 
 ### New features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ These opt-ins are enabled globally:
 
 ### Key Technologies
 
-- Kotlin 2.4.0 with JVM target 17 (KMP modules additionally target JS, wasmJs, and Native)
+- Kotlin 2.4.10 with JVM target 17 (KMP modules additionally target JS, wasmJs, and Native)
 - Gradle 9.6.1 with Kotlin DSL
 - Kotest + MockK for testing
 - Kotlinter for linting
@@ -152,6 +152,6 @@ All modules use: `com.pambrose.common.*`
 
 ### Version Management
 
-- Project version: "3.1.0" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
+- Project version: "3.2.0" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
 - Group: "com.pambrose.common-utils" (set in `gradle.properties`)
 - All library versions in `gradle/libs.versions.toml`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/pambrose/common-utils)](https://github.com/pambrose/common-utils/releases)
 [![Maven Central](https://img.shields.io/maven-central/v/com.pambrose.common-utils/core-utils)](https://central.sonatype.com/artifact/com.pambrose.common-utils/core-utils)
 [![Tests](https://github.com/pambrose/common-utils/actions/workflows/test.yml/badge.svg)](https://github.com/pambrose/common-utils/actions/workflows/test.yml)
-[![Kotlin version](https://img.shields.io/badge/kotlin-2.4.0-red?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin version](https://img.shields.io/badge/kotlin-2.4.10-red?logo=kotlin)](http://kotlinlang.org)
 [![ktlint](https://img.shields.io/badge/ktlint%20code--style-%E2%9D%A4-FF4081)](https://pinterest.github.io/ktlint/)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/5bb4750894844031a55375227acfff6f)](https://app.codacy.com/gh/pambrose/common-utils/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![codecov](https://codecov.io/gh/pambrose/common-utils/branch/master/graph/badge.svg)](https://codecov.io/gh/pambrose/common-utils)
@@ -204,9 +204,9 @@ This library is available on [Maven Central](https://central.sonatype.com/artifa
 ```kotlin
 dependencies {
     // Include specific modules as needed
-  implementation("com.pambrose.common-utils:core-utils:3.1.0")
-  implementation("com.pambrose.common-utils:json-utils:3.1.0")
-  implementation("com.pambrose.common-utils:ktor-server-utils:3.1.0")
+  implementation("com.pambrose.common-utils:core-utils:3.2.0")
+  implementation("com.pambrose.common-utils:json-utils:3.2.0")
+  implementation("com.pambrose.common-utils:ktor-server-utils:3.2.0")
     // ... other modules
 }
 ```
@@ -222,7 +222,7 @@ root coordinate automatically. The JVM-only modules keep their plain artifact id
     <dependency>
         <groupId>com.pambrose.common-utils</groupId>
         <artifactId>core-utils-jvm</artifactId>
-      <version>3.1.0</version>
+      <version>3.2.0</version>
     </dependency>
     <!-- Add other modules as needed -->
 </dependencies>
@@ -230,7 +230,7 @@ root coordinate automatically. The JVM-only modules keep their plain artifact id
 
 ## Technology Stack
 
-- **Languages**: Kotlin 2.4.0, Java
+- **Languages**: Kotlin 2.4.10, Java
 - **Build System**: Gradle 9.6.1 with Kotlin DSL
 - **Testing**: Kotest, MockK
 - **Serialization**: Kotlinx.serialization

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,24 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
+## v3.2.0 — 2026-07-14
+
+### Highlights
+
+- **Kotlin 2.4.10**: the build toolchain moves from Kotlin 2.4.0 to 2.4.10 (patch-level compiler and
+  standard-library updates); common-utils' own source and published API are unchanged.
+- **Cleaner test build**: the grpc-utils test suite no longer emits the `io.grpc.Attributes.keys()`
+  deprecation warning. It is suppressed narrowly while keeping the assertion, since gRPC offers no public
+  replacement for enumerating attribute keys.
+
+### Dependency bumps
+
+- `kotlin` 2.4.0 → 2.4.10
+
+**Full Changelog**: https://github.com/pambrose/common-utils/compare/3.1.0...3.2.0
+
+---
+
 ## v3.1.0 — 2026-07-10
 
 ### Highlights

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.pambrose.common-utils
-version=3.1.0
+version=3.2.0
 
 kotlin.code.style=official
 kotlin.native.ignoreDisabledTargets=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ mavenPublish = "0.37.0"
 versions = "0.54.0"
 
 # Kotlin & kotlinx
-kotlin = "2.4.0"
+kotlin = "2.4.10"
 coroutines = "1.11.0"
 datetime = "0.7.1-0.6.x-compat"
 kotlinxHtml = "0.12.0"

--- a/grpc-utils/src/test/kotlin/com/pambrose/common/dsl/GrpcDslTests.kt
+++ b/grpc-utils/src/test/kotlin/com/pambrose/common/dsl/GrpcDslTests.kt
@@ -43,6 +43,7 @@ class GrpcDslTests : StringSpec() {
           set(key, "test-value")
         }
       attributes.get(key) shouldBe "test-value"
+      @Suppress("DEPRECATION")
       attributes.keys() shouldBe setOf(key)
     }
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,14 +2,14 @@
 
 > Modular Kotlin/Java utility libraries providing extension functions, DSLs, and helpers for common frameworks. Each module is independently consumable via Maven Central.
 
-- Version: 3.1.0
+- Version: 3.2.0
 - Group: com.pambrose.common-utils
 - Repository: https://github.com/pambrose/common-utils
 - Maven Central: https://central.sonatype.com/namespace/com.pambrose.common-utils
 - License: Apache 2.0
-- Kotlin: 2.4.0, JVM 17
+- Kotlin: 2.4.10, JVM 17
 - Base package: com.pambrose.common.*
-- Install: `implementation("com.pambrose.common-utils:<module>:3.1.0")`
+- Install: `implementation("com.pambrose.common-utils:<module>:3.2.0")`
 - Multiplatform: core-utils, json-utils, and ktor-client-utils are Kotlin Multiplatform (JVM, JS, wasmJs,
   Native — iOS/macOS/tvOS/watchOS/Linux/Windows); all other modules are JVM-only
 - Maven (non-Gradle) consumers of the three multiplatform modules must use the `-jvm` artifact


### PR DESCRIPTION
## Summary

Cuts the **3.2.0** release documentation and bumps the Kotlin toolchain.

- Bump project version **3.1.0 → 3.2.0** (`gradle.properties`)
- Bump **Kotlin 2.4.0 → 2.4.10** (`gradle/libs.versions.toml`)
- Add `[3.2.0]` / `v3.2.0` entries to `CHANGELOG.md` and `RELEASE_NOTES.md`
- Sync version and Kotlin references in `CLAUDE.md`, `README.md`, and `llms.txt`
- Silence the deprecated `io.grpc.Attributes.keys()` warning in the grpc-utils test suite with a scoped `@Suppress("DEPRECATION")` — gRPC offers no public replacement for enumerating attribute keys (`keysForTest()` is package-private), so the test's exact-key-set assertion is preserved. Test-only, no API or behavior change.

## Notes

- Entries are dated `2026-07-14`. The `compare/3.1.0...3.2.0` changelog link resolves once both tags are pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)