### PR TITLE
Adopt Kotlin 2.4 collection-literal syntax across all modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,10 @@ val experimentalOptIns = listOf(
 
 val returnValueCheckerArg = "-Xreturn-value-checker=check"
 
+// Experimental in Kotlin 2.4: enables `[a, b]` collection-literal syntax. Applied to
+// every compilation (main and test) since the syntax is used in both.
+val collectionLiteralsArg = "-Xcollection-literals"
+
 fun DokkaExtension.configureHtml() {
     pluginsConfiguration.html {
         homepageLink.set(projectHomepage)
@@ -238,6 +242,12 @@ fun Project.configureKotlinJvm() {
                 freeCompilerArgs.add(returnValueCheckerArg)
             }
         }
+
+        tasks.withType<KotlinCompile>().configureEach {
+            compilerOptions {
+                freeCompilerArgs.add(collectionLiteralsArg)
+            }
+        }
     }
 }
 
@@ -275,6 +285,13 @@ fun Project.configureKotlinMultiplatform() {
                 compileTaskProvider.configure {
                     compilerOptions {
                         freeCompilerArgs.add(returnValueCheckerArg)
+                    }
+                }
+            }
+            compilations.configureEach {
+                compileTaskProvider.configure {
+                    compilerOptions {
+                        freeCompilerArgs.add(collectionLiteralsArg)
                     }
                 }
             }

--- a/core-utils/src/commonTest/kotlin/com/pambrose/util/StringExtensionTests.kt
+++ b/core-utils/src/commonTest/kotlin/com/pambrose/util/StringExtensionTests.kt
@@ -149,20 +149,20 @@ class StringExtensionTests : StringSpec() {
     }
 
     "test paths" {
-      listOf("a", "b", "c").join() shouldBe "a/b/c"
-      listOf("a", "b", "c").toPath() shouldBe "/a/b/c/"
-      listOf("a", "b", "c").toRootPath() shouldBe "/a/b/c"
-      listOf("a", "b", "c").toRootPath(true) shouldBe "/a/b/c/"
-      listOf("a", "b", "c").toPath(addPrefix = false, addTrailing = true) shouldBe "a/b/c/"
-      listOf("a", "b", "c").toPath() shouldBe "/a/b/c/"
-      listOf("/a", "/b", "c").toPath() shouldBe "/a/b/c/"
-      listOf("/a", "/b", "c/").toPath() shouldBe "/a/b/c/"
-      listOf("a", "/b", "c/").toPath() shouldBe "/a/b/c/"
+      ["a", "b", "c"].join() shouldBe "a/b/c"
+      ["a", "b", "c"].toPath() shouldBe "/a/b/c/"
+      ["a", "b", "c"].toRootPath() shouldBe "/a/b/c"
+      ["a", "b", "c"].toRootPath(true) shouldBe "/a/b/c/"
+      ["a", "b", "c"].toPath(addPrefix = false, addTrailing = true) shouldBe "a/b/c/"
+      ["a", "b", "c"].toPath() shouldBe "/a/b/c/"
+      ["/a", "/b", "c"].toPath() shouldBe "/a/b/c/"
+      ["/a", "/b", "c/"].toPath() shouldBe "/a/b/c/"
+      ["a", "/b", "c/"].toPath() shouldBe "/a/b/c/"
 
-      listOf("a", "b", "c").join() shouldBe "a/b/c"
-      listOf("a/", "/b/", "c").join() shouldBe "a/b/c"
-      listOf("/a/", "/b/", "c").join() shouldBe "/a/b/c"
-      listOf("/a/", "/b/", "/c").join() shouldBe "/a/b/c"
+      ["a", "b", "c"].join() shouldBe "a/b/c"
+      ["a/", "/b/", "c"].join() shouldBe "a/b/c"
+      ["/a/", "/b/", "c"].join() shouldBe "/a/b/c"
+      ["/a/", "/b/", "/c"].join() shouldBe "/a/b/c"
     }
 
     "test line indexes" {
@@ -198,9 +198,9 @@ class StringExtensionTests : StringSpec() {
       ccc
       """.trimIndent()
 
-      s.linesBetween(Regex("aaa"), Regex("ccc")) shouldBe listOf("bbb", "ccc", "aaa", "bbb")
-      s.linesBetween(Regex("ccc"), Regex("bbb")) shouldBe listOf("aaa")
-      s.linesBetween(Regex("ccc"), Regex("aaa")) shouldBe listOf()
+      s.linesBetween(Regex("aaa"), Regex("ccc")) shouldBe ["bbb", "ccc", "aaa", "bbb"]
+      s.linesBetween(Regex("ccc"), Regex("bbb")) shouldBe ["aaa"]
+      s.linesBetween(Regex("ccc"), Regex("aaa")) shouldBe []
     }
 
     "bracket test" {

--- a/core-utils/src/jvmMain/kotlin/com/pambrose/common/util/ContentSource.kt
+++ b/core-utils/src/jvmMain/kotlin/com/pambrose/common/util/ContentSource.kt
@@ -85,7 +85,7 @@ abstract class AbstractRepo(
   val ownerName: String,
   val repoName: String,
 ) : ContentRoot {
-  override val sourcePrefix: String get() = scheme + listOf(domainName, ownerName, repoName).join()
+  override val sourcePrefix: String get() = scheme + [domainName, ownerName, repoName].join()
   override val remote = true
 
   /** The URL prefix used to access raw file content from this repository. */
@@ -175,14 +175,14 @@ open class GitHubFile(
   val srcPath: String,
   val fileName: String,
 ) : UrlSource(
-  repo.scheme + listOf(
+  repo.scheme + [
     GITHUB_USER_CONTENT,
     repo.ownerName,
     repo.repoName,
     branchName,
     srcPath,
     fileName,
-  ).join(),
+  ].join(),
 ) {
   override fun toString() = "GitHubFile(repo=$repo, branchName='$branchName', srcPath='$srcPath', fileName='$fileName')"
 }
@@ -203,7 +203,7 @@ open class GitLabFile(
   val srcPath: String,
   val fileName: String,
 ) : UrlSource(
-  repo.scheme + listOf(
+  repo.scheme + [
     repo.domainName,
     repo.ownerName,
     repo.repoName,
@@ -211,7 +211,7 @@ open class GitLabFile(
     branchName,
     srcPath,
     fileName,
-  ).join(),
+  ].join(),
 ) {
   override fun toString() = "GitLabFile(repo=$repo, branchName='$branchName', srcPath='$srcPath', fileName='$fileName')"
 }

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/BugFixVerificationTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/BugFixVerificationTests.kt
@@ -223,7 +223,7 @@ class BugFixVerificationTests : StringSpec() {
     }
 
     "short times passes correct indices" {
-      val indices = mutableListOf<Short>()
+      val indices: MutableList<Short> = []
       val n: Short = 5
       n times { indices.add(it) }
       indices shouldBe listOf<Short>(0, 1, 2, 3, 4)

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/BugFixVerificationTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/BugFixVerificationTests.kt
@@ -174,7 +174,7 @@ class BugFixVerificationTests : StringSpec() {
 
     "lines between works when patterns exist" {
       val text = "aaa\nbbb\nccc\nddd"
-      text.linesBetween(Regex("aaa"), Regex("ddd")) shouldBe listOf("bbb", "ccc")
+      text.linesBetween(Regex("aaa"), Regex("ddd")) shouldBe ["bbb", "ccc"]
     }
 
     // Bug #20: JSON key "build_time: " had a trailing colon and space
@@ -226,7 +226,7 @@ class BugFixVerificationTests : StringSpec() {
       val indices: MutableList<Short> = []
       val n: Short = 5
       n times { indices.add(it) }
-      indices shouldBe listOf<Short>(0, 1, 2, 3, 4)
+      indices shouldBe [0, 1, 2, 3, 4]
     }
 
     "short times zero does nothing" {

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/ListUtilsTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/ListUtilsTests.kt
@@ -27,14 +27,14 @@ class ListUtilsTests : StringSpec() {
   init {
     "list print string test" {
       val output = captureStdout {
-        ListUtils.listPrint(listOf("a", "b", "c"))
+        ListUtils.listPrint(["a", "b", "c"])
       }
       output.trim() shouldBe "[\"a\", \"b\", \"c\"]"
     }
 
     "list print int test" {
       val output = captureStdout {
-        ListUtils.listPrint(listOf(1, 2, 3))
+        ListUtils.listPrint([1, 2, 3])
       }
       output.trim() shouldBe "[1, 2, 3]"
     }
@@ -49,7 +49,7 @@ class ListUtilsTests : StringSpec() {
     "list print mixed types test" {
       // When list contains non-String types, should use toString()
       val output = captureStdout {
-        ListUtils.listPrint(listOf(1.5, 2.5, 3.5))
+        ListUtils.listPrint([1.5, 2.5, 3.5])
       }
       output.trim() shouldBe "[1.5, 2.5, 3.5]"
     }
@@ -59,21 +59,21 @@ class ListUtilsTests : StringSpec() {
     // other types use toString().
     "list print mixed string and non-string types" {
       val output = captureStdout {
-        ListUtils.listPrint(listOf(1, "a", 2.5))
+        ListUtils.listPrint([1, "a", 2.5])
       }
       output.trim() shouldBe "[1, \"a\", 2.5]"
     }
 
     "list print mixed types with a leading string" {
       val output = captureStdout {
-        ListUtils.listPrint(listOf("x", 1, true))
+        ListUtils.listPrint(["x", 1, true])
       }
       output.trim() shouldBe "[\"x\", 1, true]"
     }
 
     "list print quotes strings and stringifies nulls in a mixed list" {
       val output = captureStdout {
-        ListUtils.listPrint(listOf("a", null, 1))
+        ListUtils.listPrint(["a", null, 1])
       }
       output.trim() shouldBe "[\"a\", null, 1]"
     }

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/MiscExtensionsTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/MiscExtensionsTests.kt
@@ -39,16 +39,16 @@ class MiscExtensionsTests : StringSpec() {
     "simple class name test" {
       "hello".simpleClassName shouldBe "String"
       42.simpleClassName shouldBe "Int"
-      listOf(1, 2, 3).simpleClassName shouldBe "ArrayList"
+      [1, 2, 3].simpleClassName shouldBe "ArrayList"
       // Single entry maps may use optimized implementations like SingletonMap
       mapOf("a" to 1, "b" to 2).simpleClassName shouldBe "LinkedHashMap"
     }
 
     "to csv test" {
       emptyList<String>().toCsv() shouldBe ""
-      listOf("a").toCsv() shouldBe "a"
-      listOf("a", "b", "c").toCsv() shouldBe "a, b, c"
-      listOf(1, 2, 3).toCsv() shouldBe "1, 2, 3"
+      ["a"].toCsv() shouldBe "a"
+      ["a", "b", "c"].toCsv() shouldBe "a, b, c"
+      [1, 2, 3].toCsv() shouldBe "1, 2, 3"
     }
   }
 }

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/MiscFuncsTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/MiscFuncsTests.kt
@@ -117,7 +117,7 @@ class MiscFuncsTests : StringSpec() {
     "repeatWithSleep invokes the block with each iteration index" {
       val seen: MutableList<Int> = []
       repeatWithSleep(iterations = 3, sleepTime = 1.milliseconds) { i, _ -> seen += i }
-      seen shouldBe listOf(0, 1, 2)
+      seen shouldBe [0, 1, 2]
     }
 
     "repeatWithSleep with the default sleepTime and zero iterations never invokes the block" {

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/MiscFuncsTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/MiscFuncsTests.kt
@@ -115,7 +115,7 @@ class MiscFuncsTests : StringSpec() {
     }
 
     "repeatWithSleep invokes the block with each iteration index" {
-      val seen = mutableListOf<Int>()
+      val seen: MutableList<Int> = []
       repeatWithSleep(iterations = 3, sleepTime = 1.milliseconds) { i, _ -> seen += i }
       seen shouldBe listOf(0, 1, 2)
     }

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/PropertyFunctionsTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/PropertyFunctionsTests.kt
@@ -59,7 +59,7 @@ class PropertyFunctionsTests : StringSpec() {
           """.trimIndent(),
         )
 
-      readProperties(listOf(file.absolutePath))
+      readProperties([file.absolutePath])
 
       System.getProperty("${KEY_PREFIX}host") shouldBe "localhost"
       System.getProperty("${KEY_PREFIX}port") shouldBe "8080"
@@ -76,7 +76,7 @@ class PropertyFunctionsTests : StringSpec() {
     "readProperties trims whitespace around keys and values" {
       val file = writePropsFile("   ${KEY_PREFIX}name   =    Paul Ambrose   ")
 
-      readProperties(listOf(file.absolutePath))
+      readProperties([file.absolutePath])
 
       System.getProperty("${KEY_PREFIX}name") shouldBe "Paul Ambrose"
     }
@@ -85,7 +85,7 @@ class PropertyFunctionsTests : StringSpec() {
       val url = "jdbc:mysql://host:3306/db?user=admin&ssl=true"
       val file = writePropsFile("${KEY_PREFIX}url=$url")
 
-      readProperties(listOf(file.absolutePath))
+      readProperties([file.absolutePath])
 
       System.getProperty("${KEY_PREFIX}url") shouldBe url
     }
@@ -93,7 +93,7 @@ class PropertyFunctionsTests : StringSpec() {
     "readProperties supports keys with an empty value" {
       val file = writePropsFile("${KEY_PREFIX}empty=")
 
-      readProperties(listOf(file.absolutePath))
+      readProperties([file.absolutePath])
 
       System.getProperty("${KEY_PREFIX}empty") shouldBe ""
     }
@@ -107,7 +107,7 @@ class PropertyFunctionsTests : StringSpec() {
           """.trimIndent(),
         )
 
-      readProperties(listOf(file.absolutePath))
+      readProperties([file.absolutePath])
 
       System.getProperty("${KEY_PREFIX}comment") shouldBe null
       System.getProperty("${KEY_PREFIX}real") shouldBe "value"
@@ -123,7 +123,7 @@ class PropertyFunctionsTests : StringSpec() {
           """.trimIndent(),
         )
 
-      readProperties(listOf(file.absolutePath))
+      readProperties([file.absolutePath])
 
       System.getProperty("${KEY_PREFIX}kept") shouldBe "yes"
     }
@@ -143,7 +143,7 @@ class PropertyFunctionsTests : StringSpec() {
 
       val exception =
         shouldThrow<IllegalStateException> {
-          readProperties(listOf(missing.path))
+          readProperties([missing.path])
         }
       exception.message shouldContain "File not found"
       exception.message shouldContain missing.absolutePath

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/ReflectExtensionTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/ReflectExtensionTests.kt
@@ -28,7 +28,7 @@ class ReflectExtensionTests : StringSpec() {
     "type param count test" {
       4.typeParameterCount shouldBe 0
       "dd".typeParameterCount shouldBe 0
-      listOf(3).typeParameterCount shouldBe 1
+      [3].typeParameterCount shouldBe 1
       mapOf(3 to "d").typeParameterCount shouldBe 2
       mutableMapOf("k1" to 1).typeParameterCount shouldBe 2
       arrayOf(4).typeParameterCount shouldBe 1

--- a/core-utils/src/jvmTest/kotlin/com/pambrose/util/SingleAssignVarTests.kt
+++ b/core-utils/src/jvmTest/kotlin/com/pambrose/util/SingleAssignVarTests.kt
@@ -61,8 +61,8 @@ class SingleAssignVarTests : StringSpec() {
 
       var listValue: List<String>? by SingleAssignVar.singleAssign()
       listValue shouldBe null
-      listValue = listOf("a", "b", "c")
-      listValue shouldBe listOf("a", "b", "c")
+      listValue = ["a", "b", "c"]
+      listValue shouldBe ["a", "b", "c"]
     }
   }
 }

--- a/email-utils/src/test/kotlin/com/pambrose/common/email/ResendServiceTests.kt
+++ b/email-utils/src/test/kotlin/com/pambrose/common/email/ResendServiceTests.kt
@@ -51,18 +51,18 @@ class ResendServiceTests : StringSpec() {
 
       ResendService("test-api-key").sendEmail(
         from = Email("Sender@Example.com"),
-        to = listOf(Email("a@example.com"), Email("b@example.com")),
-        cc = listOf(Email("cc@example.com")),
-        bcc = listOf(Email("bcc@example.com")),
+        to = [Email("a@example.com"), Email("b@example.com")],
+        cc = [Email("cc@example.com")],
+        bcc = [Email("bcc@example.com")],
         subject = "Hello",
         html = "<h1>Hi</h1>",
       )
 
       val req = captured.captured
       req.from shouldBe "Sender@Example.com"
-      req.to shouldBe listOf("a@example.com", "b@example.com")
-      req.cc shouldBe listOf("cc@example.com")
-      req.bcc shouldBe listOf("bcc@example.com")
+      req.to shouldBe ["a@example.com", "b@example.com"]
+      req.cc shouldBe ["cc@example.com"]
+      req.bcc shouldBe ["bcc@example.com"]
       req.subject shouldBe "Hello"
       req.html shouldBe "<h1>Hi</h1>"
     }
@@ -77,13 +77,13 @@ class ResendServiceTests : StringSpec() {
       // cc and bcc omitted -> exercise the emptyList() defaults
       ResendService("test-api-key").sendEmail(
         from = Email("from@example.com"),
-        to = listOf(Email("only@example.com")),
+        to = [Email("only@example.com")],
         subject = "Subj",
         html = "<p>body</p>",
       )
 
       val req = captured.captured
-      req.to shouldBe listOf("only@example.com")
+      req.to shouldBe ["only@example.com"]
       req.cc shouldBe emptyList()
       req.bcc shouldBe emptyList()
     }
@@ -97,7 +97,7 @@ class ResendServiceTests : StringSpec() {
       // Should not throw.
       ResendService("test-api-key").sendEmail(
         from = Email("from@example.com"),
-        to = listOf(Email("to@example.com")),
+        to = [Email("to@example.com")],
         subject = "Subj",
         html = "<p>x</p>",
       )
@@ -114,7 +114,7 @@ class ResendServiceTests : StringSpec() {
         shouldThrow<ResendException> {
           ResendService("test-api-key").sendEmail(
             from = Email("from@example.com"),
-            to = listOf(Email("to@example.com")),
+            to = [Email("to@example.com")],
             subject = "Subj",
             html = "<p>x</p>",
           )

--- a/email-utils/src/test/kotlin/com/pambrose/common/webhook/WebhookDataTests.kt
+++ b/email-utils/src/test/kotlin/com/pambrose/common/webhook/WebhookDataTests.kt
@@ -90,10 +90,10 @@ class WebhookDataTests : StringSpec() {
     }
 
     "data construction with all fields" {
-      val headers = listOf(
+      val headers = [
         Header(name = "X-Tag", value = "important"),
         Header(name = "X-Priority", value = "high"),
-      )
+      ]
       val bounce = Bounce(message = "mailbox full")
       val click = Click(
         ipAddress = "10.0.0.1",
@@ -106,13 +106,13 @@ class WebhookDataTests : StringSpec() {
         emailId = "email-456",
         from = "sender@example.com",
         subject = "Test Subject",
-        to = listOf("recipient1@example.com", "recipient2@example.com"),
+        to = ["recipient1@example.com", "recipient2@example.com"],
         headers = headers,
         bounce = bounce,
         click = click,
       )
       data.subject shouldBe "Test Subject"
-      data.to shouldBe listOf("recipient1@example.com", "recipient2@example.com")
+      data.to shouldBe ["recipient1@example.com", "recipient2@example.com"]
       data.headers shouldBe headers
       data.bounce shouldBe bounce
       data.click shouldBe click
@@ -124,8 +124,8 @@ class WebhookDataTests : StringSpec() {
         emailId = "email-789",
         from = "sender@example.com",
         subject = "Hello",
-        to = listOf("user@test.com"),
-        headers = listOf(Header(name = "X-Test", value = "abc")),
+        to = ["user@test.com"],
+        headers = [Header(name = "X-Test", value = "abc")],
       )
       val json = Json.encodeToString(data)
       val decoded = Json.decodeFromString<Data>(json)
@@ -154,7 +154,7 @@ class WebhookDataTests : StringSpec() {
         emailId = "email-200",
         from = "sender@test.com",
         subject = "Welcome",
-        to = listOf("new-user@test.com"),
+        to = ["new-user@test.com"],
       )
       val msg = ResendWebhookMsg(
         createdAt = "2026-01-01T00:00:00Z",
@@ -171,11 +171,11 @@ class WebhookDataTests : StringSpec() {
         createdAt = "2026-02-01T00:00:00Z",
         emailId = "email-300",
         from = "admin@example.com",
-        to = listOf("a@test.com", "b@test.com", "c@test.com"),
-        headers = listOf(
+        to = ["a@test.com", "b@test.com", "c@test.com"],
+        headers = [
           Header(name = "X-First", value = "1"),
           Header(name = "X-Second", value = "2"),
-        ),
+        ],
       )
       val json = Json.encodeToString(data)
       val decoded = Json.decodeFromString<Data>(json)
@@ -230,8 +230,8 @@ class WebhookDataTests : StringSpec() {
         emailId = "email-400",
         from = "sender@example.com",
         subject = "Bounced and clicked",
-        to = listOf("user@test.com"),
-        headers = listOf(Header(name = "X-Env", value = "prod")),
+        to = ["user@test.com"],
+        headers = [Header(name = "X-Env", value = "prod")],
         bounce = Bounce(message = "mailbox unavailable"),
         click = Click(
           ipAddress = "10.1.1.1",

--- a/exposed-utils/src/test/kotlin/com/pambrose/common/exposed/KotlinSqlLoggerTests.kt
+++ b/exposed-utils/src/test/kotlin/com/pambrose/common/exposed/KotlinSqlLoggerTests.kt
@@ -67,7 +67,7 @@ class KotlinSqlLoggerTests : StringSpec() {
     }
 
     "log writes the expanded sql statement at info level" {
-      val messages = mutableListOf<String>()
+      val messages: MutableList<String> = []
       val mockLogger = mockk<KLogger>()
       every { mockLogger.info(any<() -> Any?>()) } answers {
         messages += firstArg<() -> Any?>().invoke().toString()

--- a/grpc-utils/src/test/kotlin/com/pambrose/common/dsl/GrpcDslTests.kt
+++ b/grpc-utils/src/test/kotlin/com/pambrose/common/dsl/GrpcDslTests.kt
@@ -72,7 +72,7 @@ class GrpcDslTests : StringSpec() {
         response shouldBe "echo: hello"
         serverBlockCalled shouldBe true
         channelBlockCalled shouldBe true
-        server.services.map { it.serviceDescriptor.name } shouldBe listOf("EchoService")
+        server.services.map { it.serviceDescriptor.name } shouldBe ["EchoService"]
       } finally {
         channel.shutdownNow()
         server.shutdownNow()
@@ -125,7 +125,7 @@ class GrpcDslTests : StringSpec() {
           addService(echoService())
         }
       blockCalled shouldBe true
-      server.services.map { it.serviceDescriptor.name } shouldBe listOf("EchoService")
+      server.services.map { it.serviceDescriptor.name } shouldBe ["EchoService"]
       server.isShutdown shouldBe false
     }
 

--- a/grpc-utils/src/test/kotlin/com/pambrose/common/dsl/StreamObserverHelperTests.kt
+++ b/grpc-utils/src/test/kotlin/com/pambrose/common/dsl/StreamObserverHelperTests.kt
@@ -88,7 +88,7 @@ class StreamObserverHelperTests : StringSpec() {
       observer.onNext("second")
       observer.onCompleted()
 
-      receivedValues shouldBe listOf("first", "second")
+      receivedValues shouldBe ["first", "second"]
       errorReceived shouldBe null
       completedCalled shouldBe true
     }

--- a/grpc-utils/src/test/kotlin/com/pambrose/common/dsl/StreamObserverHelperTests.kt
+++ b/grpc-utils/src/test/kotlin/com/pambrose/common/dsl/StreamObserverHelperTests.kt
@@ -67,7 +67,7 @@ class StreamObserverHelperTests : StringSpec() {
     }
 
     "all callbacks" {
-      val receivedValues = mutableListOf<String>()
+      val receivedValues: MutableList<String> = []
       var errorReceived: Throwable? = null
       var completedCalled = false
 

--- a/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/ConditionalValue.kt
+++ b/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/ConditionalValue.kt
@@ -112,7 +112,7 @@ fun main() =
     }
 
     yield()
-    for (s in listOf(false, false, true)) {
+    for (s in [false, false, true]) {
       println("Setting value to $s")
       waiter.set(s)
       delay(1.seconds)
@@ -144,7 +144,7 @@ fun main2() =
 
 fun main3() =
   runBlocking {
-    val waiter = ConditionalValue(listOf(1))
+    val waiter = ConditionalValue([1])
 
     // Launch a coroutine that waits for the condition to become true
     val job = launch {
@@ -176,7 +176,7 @@ fun main4() =
     }
 
     yield()
-    for (s in listOf("Bill", "Bob", "Paul", "John").map { "$it Ambrose" }) {
+    for (s in ["Bill", "Bob", "Paul", "John"].map { "$it Ambrose" }) {
       println("Setting value to $s  curr: ${waiter.get()}")
       waiter.set(s)
       delay(1.seconds)

--- a/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/GenericValueWaiter.kt
+++ b/guava-utils/src/main/kotlin/com/pambrose/common/concurrent/GenericValueWaiter.kt
@@ -86,7 +86,7 @@ abstract class GenericValueWaiter<T>(
   protected val initValue: T,
 ) {
   private val lock = ReentrantLock()
-  private val waiters = mutableListOf<Waiter>()
+  private val waiters: MutableList<Waiter> = []
 
   protected var currValue = initValue
 
@@ -153,8 +153,8 @@ abstract class GenericValueWaiter<T>(
    * @param value the new value.
    */
   fun checkCondition(value: T) {
-    val satisfied = mutableListOf<Waiter>()
-    val failed = mutableListOf<Pair<Waiter, Throwable>>()
+    val satisfied: MutableList<Waiter> = []
+    val failed: MutableList<Pair<Waiter, Throwable>> = []
     lock.withLock {
       currValue = value
       // Evaluate each predicate in isolation so a single misbehaving one cannot starve the others, and

--- a/guava-utils/src/test/kotlin/com/pambrose/util/ConditionalTests.kt
+++ b/guava-utils/src/test/kotlin/com/pambrose/util/ConditionalTests.kt
@@ -31,9 +31,9 @@ import kotlin.time.Duration.Companion.seconds
 class ConditionalTests : StringSpec() {
   init {
     "simple bools" {
-      val results = mutableListOf<Int>()
+      val results: MutableList<Int> = []
       val mutex = Mutex()
-      val jobs = mutableListOf<Job>()
+      val jobs: MutableList<Job> = []
       val bool1 = ConditionalBoolean(false)
       val bool2 = ConditionalBoolean(false)
       val bool3 = ConditionalBoolean(false)
@@ -65,9 +65,9 @@ class ConditionalTests : StringSpec() {
 
     "list bools" {
       val mutex = Mutex()
-      val jobs = mutableListOf<Job>()
-      val results = mutableListOf<Int>()
-      val expected = mutableListOf<Int>()
+      val jobs: MutableList<Job> = []
+      val results: MutableList<Int> = []
+      val expected: MutableList<Int> = []
       val bools = List(1000) { it to ConditionalBoolean(false) }
 
       for ((id, bool) in bools) {
@@ -89,9 +89,9 @@ class ConditionalTests : StringSpec() {
 
     "multi int listeners" {
       val mutex = Mutex()
-      val jobs = mutableListOf<Job>()
-      val results = mutableListOf<Int>()
-      val expected = mutableListOf<Int>()
+      val jobs: MutableList<Job> = []
+      val results: MutableList<Int> = []
+      val expected: MutableList<Int> = []
       val vals = List(1000) { it to ConditionalValue(-1) }
 
       for ((id, cv) in vals.shuffled()) {
@@ -113,10 +113,10 @@ class ConditionalTests : StringSpec() {
 
     "multi list listeners" {
       val mutex = Mutex()
-      val jobs = mutableListOf<Job>()
-      val results = mutableListOf<Int>()
-      val expected = mutableListOf<Int>()
-      val listVals = mutableListOf<Int>()
+      val jobs: MutableList<Job> = []
+      val results: MutableList<Int> = []
+      val expected: MutableList<Int> = []
+      val listVals: MutableList<Int> = []
       val vals = List(1000) { it to ConditionalValue(emptyList<Int>()) }
 
       for ((id, cv) in vals.shuffled()) {

--- a/guava-utils/src/test/kotlin/com/pambrose/util/ConditionalTests.kt
+++ b/guava-utils/src/test/kotlin/com/pambrose/util/ConditionalTests.kt
@@ -60,7 +60,7 @@ class ConditionalTests : StringSpec() {
 
       jobs.joinAll()
 
-      results shouldBe listOf(3, 1, 2)
+      results shouldBe [3, 1, 2]
     }
 
     "list bools" {

--- a/jetty-utils/src/test/kotlin/com/pambrose/common/servlet/VersionServletTests.kt
+++ b/jetty-utils/src/test/kotlin/com/pambrose/common/servlet/VersionServletTests.kt
@@ -58,7 +58,7 @@ class VersionServletTests : StringSpec() {
     }
 
     "different version strings work correctly" {
-      val versions = listOf("2.5.3", "0.0.1-SNAPSHOT", "3.0.0-beta.1")
+      val versions = ["2.5.3", "0.0.1-SNAPSHOT", "3.0.0-beta.1"]
 
       for (version in versions) {
         val request = createGetRequest()

--- a/json-utils/src/commonTest/kotlin/com/pambrose/json/BugFixVerificationTests.kt
+++ b/json-utils/src/commonTest/kotlin/com/pambrose/json/BugFixVerificationTests.kt
@@ -83,10 +83,10 @@ class BugFixVerificationTests : StringSpec() {
         JsonObject(
           mapOf(
             "matrix" to JsonArray(
-              listOf(
-                JsonArray(listOf(JsonPrimitive(1), JsonPrimitive(2))),
-                JsonArray(listOf(JsonPrimitive(3), JsonPrimitive(4))),
-              ),
+              [
+                JsonArray([JsonPrimitive(1), JsonPrimitive(2)]),
+                JsonArray([JsonPrimitive(3), JsonPrimitive(4)]),
+              ],
             ),
           ),
         )
@@ -96,10 +96,10 @@ class BugFixVerificationTests : StringSpec() {
       matrix.size shouldBe 2
 
       val row1 = matrix[0] as List<*>
-      row1 shouldBe listOf("1", "2")
+      row1 shouldBe ["1", "2"]
 
       val row2 = matrix[1] as List<*>
-      row2 shouldBe listOf("3", "4")
+      row2 shouldBe ["3", "4"]
     }
 
     "to map handles mixed nested arrays" {
@@ -107,12 +107,12 @@ class BugFixVerificationTests : StringSpec() {
         JsonObject(
           mapOf(
             "items" to JsonArray(
-              listOf(
+              [
                 JsonObject(mapOf("name" to JsonPrimitive("a"))),
-                JsonArray(listOf(JsonPrimitive("nested"))),
+                JsonArray([JsonPrimitive("nested")]),
                 JsonPrimitive("plain"),
                 JsonNull,
-              ),
+              ],
             ),
           ),
         )
@@ -121,7 +121,7 @@ class BugFixVerificationTests : StringSpec() {
       val items = map["items"] as List<*>
       items.size shouldBe 4
       (items[0] as Map<*, *>)["name"] shouldBe "a"
-      items[1] shouldBe listOf("nested")
+      items[1] shouldBe ["nested"]
       items[2] shouldBe "plain"
       items[3] shouldBe null
     }
@@ -131,13 +131,13 @@ class BugFixVerificationTests : StringSpec() {
         JsonObject(
           mapOf(
             "deep" to JsonArray(
-              listOf(
+              [
                 JsonArray(
-                  listOf(
-                    JsonArray(listOf(JsonPrimitive("innermost"))),
-                  ),
+                  [
+                    JsonArray([JsonPrimitive("innermost")]),
+                  ],
                 ),
-              ),
+              ],
             ),
           ),
         )
@@ -146,7 +146,7 @@ class BugFixVerificationTests : StringSpec() {
       val deep = map["deep"] as List<*>
       val mid = (deep[0] as List<*>)
       val inner = (mid[0] as List<*>)
-      inner shouldBe listOf("innermost")
+      inner shouldBe ["innermost"]
     }
   }
 }

--- a/json-utils/src/commonTest/kotlin/com/pambrose/json/JsonContentUtilsTest.kt
+++ b/json-utils/src/commonTest/kotlin/com/pambrose/json/JsonContentUtilsTest.kt
@@ -52,10 +52,10 @@ class JsonContentUtilsTest : StringSpec() {
     val complexData = ComplexData(
       id = "complex-1",
       metadata = mapOf("version" to "1.0", "type" to "test"),
-      items = listOf(
+      items = [
         SimpleData("item1", 10),
         SimpleData("item2", 20, false),
-      ),
+      ],
     )
 
     "JsonContentUtils formats are properly configured" {

--- a/json-utils/src/commonTest/kotlin/com/pambrose/json/JsonElementUtilsTest.kt
+++ b/json-utils/src/commonTest/kotlin/com/pambrose/json/JsonElementUtilsTest.kt
@@ -81,12 +81,12 @@ class JsonElementUtilsTest : StringSpec() {
       email = "john@example.com",
       active = true,
       score = 95.5,
-      tags = listOf("developer", "kotlin"),
+      tags = ["developer", "kotlin"],
     )
 
     val sampleCompany = TestCompany(
       name = "Tech Corp",
-      users = listOf(sampleUser),
+      users = [sampleUser],
       metadata = mapOf("founded" to "2020", "size" to "startup"),
     )
 

--- a/json-utils/src/commonTest/kotlin/com/pambrose/json/JsonTests.kt
+++ b/json-utils/src/commonTest/kotlin/com/pambrose/json/JsonTests.kt
@@ -142,7 +142,7 @@ class JsonTests : StringSpec() {
     }
 
     "Object types" {
-      listOf(json1, json2).forEach { json ->
+      [json1, json2].forEach { json ->
         val objVal = json.jsonObjectValue("objectVal")
         objVal.booleanValue("boolVal") shouldBe DEFAULT_BOOLEAN
         objVal.stringValue("strVal") shouldBe DEFAULT_STRING
@@ -152,7 +152,7 @@ class JsonTests : StringSpec() {
     }
 
     "List types" {
-      listOf(json1, json2).forEach { json ->
+      [json1, json2].forEach { json ->
         json.jsonElementList("boolList").map { it.booleanValue } shouldBe DEFAULT_BOOLEAN_LIST
         json.jsonElementList("strList").map { it.stringValue } shouldBe DEFAULT_STRING_LIST
         json.jsonElementList("intList").map { it.intValue } shouldBe DEFAULT_INT_LIST
@@ -161,7 +161,7 @@ class JsonTests : StringSpec() {
     }
 
     "Embedded object types" {
-      listOf(json1, json2).forEach { json ->
+      [json1, json2].forEach { json ->
         json.booleanValue("objectVal.boolVal") shouldBe DEFAULT_BOOLEAN
         json.stringValue("objectVal.strVal") shouldBe DEFAULT_STRING
         json.intValue("objectVal.intVal") shouldBe DEFAULT_INT

--- a/json-utils/src/jvmTest/kotlin/com/pambrose/json/JsonIntegrationTest.kt
+++ b/json-utils/src/jvmTest/kotlin/com/pambrose/json/JsonIntegrationTest.kt
@@ -107,7 +107,7 @@ class JsonIntegrationTest : StringSpec() {
           "linkedin" to "https://linkedin.com/in/johndoe",
         ),
       ),
-      permissions = listOf("read", "write", "admin"),
+      permissions = ["read", "write", "admin"],
       settings = UserSettings(
         theme = "dark",
         notifications = NotificationSettings(
@@ -317,11 +317,11 @@ class JsonIntegrationTest : StringSpec() {
 
     "bulk data processing" {
       // Simulate processing a batch of users
-      val users = listOf(
+      val users = [
         sampleUser.copy(id = 1, username = "user1"),
         sampleUser.copy(id = 2, username = "user2", settings = sampleUser.settings.copy(theme = "light")),
-        sampleUser.copy(id = 3, username = "user3", permissions = listOf("read")),
-      )
+        sampleUser.copy(id = 3, username = "user3", permissions = ["read"]),
+      ]
 
       val batchResponse = ApiResponse(
         success = true,

--- a/ktor-server-utils/src/main/kotlin/com/pambrose/common/features/HerokuHttpsRedirect.kt
+++ b/ktor-server-utils/src/main/kotlin/com/pambrose/common/features/HerokuHttpsRedirect.kt
@@ -84,7 +84,7 @@ class HerokuHttpsRedirect(
      * The list of call predicates for redirect exclusion.
      * Any call matching any of the predicates will not be redirected by this feature.
      */
-    val excludePredicates: MutableList<CallPredicate> = mutableListOf()
+    val excludePredicates: MutableList<CallPredicate> = []
 
     /**
      * Exclude calls with paths matching the [pathPrefix] from being redirected to https by this feature.

--- a/ktor-server-utils/src/main/kotlin/com/pambrose/common/servlet/KtorServletResponse.kt
+++ b/ktor-server-utils/src/main/kotlin/com/pambrose/common/servlet/KtorServletResponse.kt
@@ -64,14 +64,14 @@ class KtorServletResponse : HttpServletResponse {
     name: String,
     value: String,
   ) {
-    headers[name] = mutableListOf(value)
+    headers[name] = [value]
   }
 
   override fun addHeader(
     name: String,
     value: String,
   ) {
-    headers.getOrPut(name) { mutableListOf() }.add(value)
+    headers.getOrPut(name) { [] }.add(value)
   }
 
   override fun containsHeader(name: String): Boolean = headers.containsKey(name)

--- a/ktor-server-utils/src/test/kotlin/com/pambrose/common/servlet/KtorServletRequestTests.kt
+++ b/ktor-server-utils/src/test/kotlin/com/pambrose/common/servlet/KtorServletRequestTests.kt
@@ -81,19 +81,19 @@ class KtorServletRequestTests : StringSpec() {
 
     "getParameterValues returns null for a missing parameter" {
       val request = mockk<ApplicationRequest>()
-      every { request.queryParameters } returns parametersOf("id", listOf("42"))
+      every { request.queryParameters } returns parametersOf("id", ["42"])
       val servletRequest = KtorServletRequest(request)
-      servletRequest.getParameterValues("id")?.toList() shouldBe listOf("42")
+      servletRequest.getParameterValues("id")?.toList() shouldBe ["42"]
       servletRequest.getParameterValues("missing") shouldBe null
     }
 
     "getHeaders returns all values for a header and an empty enumeration when absent" {
       val request = mockk<ApplicationRequest>()
-      every { request.headers } returns headersOf("Accept" to listOf("text/html", "application/json"))
+      every { request.headers } returns headersOf("Accept" to ["text/html", "application/json"])
       val servletRequest = KtorServletRequest(request)
-      servletRequest.getHeaders("Accept").toList() shouldBe listOf("text/html", "application/json")
+      servletRequest.getHeaders("Accept").toList() shouldBe ["text/html", "application/json"]
       servletRequest.getHeaders("X-Missing").toList() shouldBe emptyList()
-      servletRequest.headerNames.toList() shouldBe listOf("Accept")
+      servletRequest.headerNames.toList() shouldBe ["Accept"]
     }
 
     "unsupported request methods throw UnsupportedOperationException" {

--- a/ktor-server-utils/src/test/kotlin/com/pambrose/common/servlet/KtorServletResponseTests.kt
+++ b/ktor-server-utils/src/test/kotlin/com/pambrose/common/servlet/KtorServletResponseTests.kt
@@ -46,10 +46,10 @@ class KtorServletResponseTests : StringSpec() {
 
       response.setHeader("X-Custom", "value2")
       response.getHeader("X-Custom") shouldBe "value2"
-      response.getHeaders("X-Custom").toList() shouldBe listOf("value2")
+      response.getHeaders("X-Custom").toList() shouldBe ["value2"]
 
       response.addHeader("X-Custom", "value3")
-      response.getHeaders("X-Custom").toList() shouldBe listOf("value2", "value3")
+      response.getHeaders("X-Custom").toList() shouldBe ["value2", "value3"]
       response.getHeader("X-Custom") shouldBe "value2"
 
       response.headerNames.toSet() shouldBe setOf("X-Custom")
@@ -64,7 +64,7 @@ class KtorServletResponseTests : StringSpec() {
       response.containsHeader("x-foo") shouldBe true
       response.containsHeader("X-FOO") shouldBe true
       response.getHeader("x-foo") shouldBe "a"
-      response.getHeaders("X-fOo").toList() shouldBe listOf("a")
+      response.getHeaders("X-fOo").toList() shouldBe ["a"]
     }
 
     "setHeader with different casing overwrites rather than duplicating" {
@@ -72,7 +72,7 @@ class KtorServletResponseTests : StringSpec() {
       response.setHeader("X-Foo", "a")
       response.setHeader("x-foo", "b")
 
-      response.getHeaders("X-Foo").toList() shouldBe listOf("b")
+      response.getHeaders("X-Foo").toList() shouldBe ["b"]
       response.getHeader("x-FOO") shouldBe "b"
       // A single logical header, retaining the first-inserted casing.
       response.headerNames.toSet() shouldBe setOf("X-Foo")
@@ -83,7 +83,7 @@ class KtorServletResponseTests : StringSpec() {
       response.addHeader("Set-Cookie", "a")
       response.addHeader("set-cookie", "b")
 
-      response.getHeaders("SET-COOKIE").toList() shouldBe listOf("a", "b")
+      response.getHeaders("SET-COOKIE").toList() shouldBe ["a", "b"]
       response.headerNames.toSet() shouldBe setOf("Set-Cookie")
     }
 

--- a/prometheus-utils/src/main/kotlin/com/pambrose/common/metrics/SamplerGaugeCollector.kt
+++ b/prometheus-utils/src/main/kotlin/com/pambrose/common/metrics/SamplerGaugeCollector.kt
@@ -58,7 +58,7 @@ class SamplerGaugeCollector(
         Double.NaN
       }
     val sample = MetricFamilySamples.Sample(name, labelNames, labelValues, value)
-    return listOf(MetricFamilySamples(name, Type.GAUGE, help, listOf(sample)))
+    return [MetricFamilySamples(name, Type.GAUGE, help, [sample])]
   }
 
   companion object {

--- a/prometheus-utils/src/test/kotlin/com/pambrose/common/metrics/SamplerGaugeCollectorTests.kt
+++ b/prometheus-utils/src/test/kotlin/com/pambrose/common/metrics/SamplerGaugeCollectorTests.kt
@@ -51,14 +51,14 @@ class SamplerGaugeCollectorTests : StringSpec() {
       val collector = SamplerGaugeCollector(
         name = "test_sampler_gauge_with_labels",
         help = "Test sampler gauge with labels",
-        labelNames = listOf("region", "instance"),
-        labelValues = listOf("us-east-1", "i-12345"),
+        labelNames = ["region", "instance"],
+        labelValues = ["us-east-1", "i-12345"],
         data = { 55.5 },
       )
       val samples = collector.collect()
       samples shouldHaveSize 1
-      samples[0].samples[0].labelNames shouldBe listOf("region", "instance")
-      samples[0].samples[0].labelValues shouldBe listOf("us-east-1", "i-12345")
+      samples[0].samples[0].labelNames shouldBe ["region", "instance"]
+      samples[0].samples[0].labelValues shouldBe ["us-east-1", "i-12345"]
       samples[0].samples[0].value shouldBe 55.5
     }
 
@@ -68,8 +68,8 @@ class SamplerGaugeCollectorTests : StringSpec() {
         SamplerGaugeCollector(
           name = "test_sampler_gauge_mismatch",
           help = "mismatched labels",
-          labelNames = listOf("region", "instance"),
-          labelValues = listOf("us-east-1"),
+          labelNames = ["region", "instance"],
+          labelValues = ["us-east-1"],
           data = { 1.0 },
         )
       }

--- a/recaptcha-utils/src/test/kotlin/com/pambrose/common/recaptcha/RecaptchaTests.kt
+++ b/recaptcha-utils/src/test/kotlin/com/pambrose/common/recaptcha/RecaptchaTests.kt
@@ -117,7 +117,7 @@ class RecaptchaTests : StringSpec() {
       val response = jsonParser.decodeFromString<RecaptchaService.RecaptchaResponse>(json)
 
       response.success shouldBe false
-      response.errorCodes shouldBe listOf("invalid-input-response", "timeout-or-duplicate")
+      response.errorCodes shouldBe ["invalid-input-response", "timeout-or-duplicate"]
       response.hostname shouldBe null
     }
 
@@ -146,7 +146,7 @@ class RecaptchaTests : StringSpec() {
       val response = jsonParser.decodeFromString<RecaptchaService.RecaptchaResponse>(json)
 
       response.success shouldBe false
-      response.errorCodes shouldBe listOf("timeout-or-duplicate")
+      response.errorCodes shouldBe ["timeout-or-duplicate"]
       response.hostname shouldBe "example.com"
       response.challengeTs shouldBe "2024-06-01T12:00:00Z"
     }
@@ -157,7 +157,7 @@ class RecaptchaTests : StringSpec() {
       val response = jsonParser.decodeFromString<RecaptchaService.RecaptchaResponse>(json)
 
       response.success shouldBe false
-      response.errorCodes shouldBe listOf("invalid-input-secret", "bad-request")
+      response.errorCodes shouldBe ["invalid-input-secret", "bad-request"]
       response.hostname shouldBe null
       response.challengeTs shouldBe null
     }
@@ -182,7 +182,7 @@ class RecaptchaTests : StringSpec() {
       val populated =
         RecaptchaService.RecaptchaResponse(
           success = false,
-          errorCodes = listOf("invalid-input-response"),
+          errorCodes = ["invalid-input-response"],
           hostname = "example.com",
           challengeTs = "2024-06-01T12:00:00Z",
         )
@@ -200,13 +200,13 @@ class RecaptchaTests : StringSpec() {
       val response =
         RecaptchaService.RecaptchaResponse(
           success = false,
-          errorCodes = listOf("invalid-input-secret"),
+          errorCodes = ["invalid-input-secret"],
           hostname = "example.com",
           challengeTs = "2024-06-01T12:00:00Z",
         )
 
       response.success shouldBe false
-      response.errorCodes shouldBe listOf("invalid-input-secret")
+      response.errorCodes shouldBe ["invalid-input-secret"]
       response.hostname shouldBe "example.com"
       response.challengeTs shouldBe "2024-06-01T12:00:00Z"
     }
@@ -222,12 +222,12 @@ class RecaptchaTests : StringSpec() {
 
     "recaptcha response value semantics" {
       val original = RecaptchaService.RecaptchaResponse(success = true, hostname = "localhost")
-      val changed = original.copy(success = false, errorCodes = listOf("timeout-or-duplicate"))
+      val changed = original.copy(success = false, errorCodes = ["timeout-or-duplicate"])
 
       changed shouldBe
         RecaptchaService.RecaptchaResponse(
           success = false,
-          errorCodes = listOf("timeout-or-duplicate"),
+          errorCodes = ["timeout-or-duplicate"],
           hostname = "localhost",
         )
       changed shouldNotBe original

--- a/redis-utils/src/test/kotlin/com/pambrose/common/redis/RedisUtilsMockTests.kt
+++ b/redis-utils/src/test/kotlin/com/pambrose/common/redis/RedisUtilsMockTests.kt
@@ -61,12 +61,12 @@ class RedisUtilsMockTests : StringSpec() {
       val jedis = mockk<UnifiedJedis>()
       val paramsSlot = slot<ScanParams>()
       every { jedis.scan(SCAN_POINTER_START, capture(paramsSlot)) } returns
-        ScanResult("42", listOf("user:1", "user:2"))
-      every { jedis.scan("42", any<ScanParams>()) } returns ScanResult(SCAN_POINTER_START, listOf("user:3"))
+        ScanResult("42", ["user:1", "user:2"])
+      every { jedis.scan("42", any<ScanParams>()) } returns ScanResult(SCAN_POINTER_START, ["user:3"])
 
       val keys = jedis.scanKeys("user:*", count = 25).toList()
 
-      keys shouldBe listOf("user:1", "user:2", "user:3")
+      keys shouldBe ["user:1", "user:2", "user:3"]
       // ScanParams implements equals(), so this checks both the match pattern and the count hint
       paramsSlot.captured shouldBe ScanParams().match("user:*").count(25)
       verify(exactly = 1) { jedis.scan(SCAN_POINTER_START, any<ScanParams>()) }
@@ -87,15 +87,15 @@ class RedisUtilsMockTests : StringSpec() {
 
     "scanKeys is lazy and only fetches pages as the sequence is consumed" {
       val jedis = mockk<UnifiedJedis>()
-      every { jedis.scan(SCAN_POINTER_START, any<ScanParams>()) } returns ScanResult("7", listOf("a", "b"))
-      every { jedis.scan("7", any<ScanParams>()) } returns ScanResult(SCAN_POINTER_START, listOf("c"))
+      every { jedis.scan(SCAN_POINTER_START, any<ScanParams>()) } returns ScanResult("7", ["a", "b"])
+      every { jedis.scan("7", any<ScanParams>()) } returns ScanResult(SCAN_POINTER_START, ["c"])
 
       val seq = jedis.scanKeys("*")
       // Building the sequence issues no SCAN calls
       verify(exactly = 0) { jedis.scan(any<String>(), any<ScanParams>()) }
 
       // Consuming only the first page never requests the second one
-      seq.take(2).toList() shouldBe listOf("a", "b")
+      seq.take(2).toList() shouldBe ["a", "b"]
       verify(exactly = 1) { jedis.scan(any<String>(), any<ScanParams>()) }
     }
 

--- a/script-utils-common/src/main/kotlin/com/pambrose/common/script/ScriptGuards.kt
+++ b/script-utils-common/src/main/kotlin/com/pambrose/common/script/ScriptGuards.kt
@@ -32,7 +32,7 @@ import javax.script.ScriptException
  */
 object ScriptGuards {
   private val jvmExitPatterns =
-    listOf(
+    [
       // System.exit(...), including fully-qualified java.lang.System.exit(...); not mySystem.exit(...)
       Regex("""(?<!\w)System\s*\.\s*exit\s*\("""),
       // bare exitProcess(...) (the imported Kotlin idiom); excludes obj.exitProcess(...) on a user object
@@ -43,7 +43,7 @@ object ScriptGuards {
       Regex("""(?<!\w)Runtime\s*\.\s*getRuntime\s*\(\s*\)\s*\.\s*(?:exit|halt)\s*\("""),
       // statically-imported getRuntime().exit/halt (no `Runtime.` prefix); excludes obj.getRuntime()
       Regex("""(?<![\w.])getRuntime\s*\(\s*\)\s*\.\s*(?:exit|halt)\s*\("""),
-    )
+    ]
 
   /**
    * Throws a [ScriptException] if any of [fragments] contains a recognized literal JVM-termination call.

--- a/script-utils-common/src/test/kotlin/com/pambrose/common/script/ScriptGuardsTests.kt
+++ b/script-utils-common/src/test/kotlin/com/pambrose/common/script/ScriptGuardsTests.kt
@@ -30,12 +30,12 @@ class ScriptGuardsTests : StringSpec() {
     // terminate the test JVM even when the input is a real termination call.
 
     "rejects System.exit in its common forms" {
-      listOf(
+      [
         "System.exit(0)",
         "java.lang.System.exit(1)",
         "System . exit ( 0 )",
         "return System.exit(0);",
-      ).forEach { code ->
+      ].forEach { code ->
         shouldThrow<ScriptException> { ScriptGuards.checkNoJvmExit(code) }
       }
     }
@@ -69,14 +69,14 @@ class ScriptGuardsTests : StringSpec() {
     }
 
     "does not reject safe code or unrelated identifiers" {
-      listOf(
+      [
         "val x = 1 + 2",
         "mySystem.exit(0)",
         "obj.exitProcess(args)",
         "return value;",
         "doExit()",
         "println(\"done\")",
-      ).forEach { code ->
+      ].forEach { code ->
         shouldNotThrow<ScriptException> { ScriptGuards.checkNoJvmExit(code) }
       }
     }

--- a/script-utils-common/src/test/kotlin/com/pambrose/common/script/ScriptUtilsTests.kt
+++ b/script-utils-common/src/test/kotlin/com/pambrose/common/script/ScriptUtilsTests.kt
@@ -63,7 +63,7 @@ class ScriptUtilsTests : StringSpec() {
       engine.resetContext()
 
       verify(exactly = 1) { engine.context = any() }
-      val capturedContext = mutableListOf<ScriptContext>()
+      val capturedContext: MutableList<ScriptContext> = []
       verify { engine.context = capture(capturedContext) }
       val newContext = capturedContext.first()
       newContext.shouldBeInstanceOf<javax.script.SimpleScriptContext>()

--- a/script-utils-java/src/main/kotlin/com/pambrose/common/script/JavaScript.kt
+++ b/script-utils-java/src/main/kotlin/com/pambrose/common/script/JavaScript.kt
@@ -43,7 +43,7 @@ import kotlin.reflect.typeOf
 class JavaScript :
   AbstractScript("java", false),
   Closeable {
-  private val imports = mutableListOf<String>()
+  private val imports: MutableList<String> = []
 
   /**
    * Generates Java-style public field declarations for all registered variables.
@@ -52,7 +52,7 @@ class JavaScript :
    */
   val varDecls: String
     get() {
-      val assigns = mutableListOf<String>()
+      val assigns: MutableList<String> = []
 
       valueMap.forEach { (name, value) ->
         val javaClazz = value.javaClass

--- a/script-utils-java/src/test/kotlin/com/pambrose/common/script/JavaScriptTests.kt
+++ b/script-utils-java/src/test/kotlin/com/pambrose/common/script/JavaScriptTests.kt
@@ -98,7 +98,7 @@ class JavaScriptTests : StringSpec() {
     }
 
     "object with types" {
-      val list = mutableListOf(1)
+      val list: MutableList<Int> = [1]
       val map = mutableMapOf("k1" to 1)
 
       JavaScript().use {
@@ -134,7 +134,7 @@ class JavaScriptTests : StringSpec() {
     }
 
     "object with KType" {
-      val list = mutableListOf(1)
+      val list: MutableList<Int> = [1]
 
       JavaScript().use {
         it.apply {
@@ -158,7 +158,7 @@ class JavaScriptTests : StringSpec() {
     }
 
     "null object" {
-      val list = mutableListOf<Int?>()
+      val list: MutableList<Int?> = []
 
       JavaScript().use {
         it.apply {
@@ -190,7 +190,7 @@ class JavaScriptTests : StringSpec() {
     }
 
     "unmatched params" {
-      val list = mutableListOf(1)
+      val list: MutableList<Int> = [1]
 
       JavaScript().use { script ->
         shouldThrow<ScriptException> { script.add("list", list, typeOf<Int?>(), typeOf<Int>()) }
@@ -198,7 +198,7 @@ class JavaScriptTests : StringSpec() {
     }
 
     "missing collection type" {
-      val list = mutableListOf(1)
+      val list: MutableList<Int> = [1]
       JavaScript().use { script ->
         shouldThrow<ScriptException> { script.add("list", list) }
       }

--- a/script-utils-kotlin/src/main/kotlin/com/pambrose/common/script/KotlinScript.kt
+++ b/script-utils-kotlin/src/main/kotlin/com/pambrose/common/script/KotlinScript.kt
@@ -43,7 +43,7 @@ class KotlinScript(
   nullGlobalContext: Boolean = false,
 ) : AbstractScript("kts", nullGlobalContext),
   Closeable {
-  private val imports = listOf(System::class.qualifiedName)
+  private val imports = [System::class.qualifiedName]
 
   /**
    * Generates Kotlin `val` declarations that retrieve bound variables from the engine's bindings

--- a/script-utils-kotlin/src/main/kotlin/com/pambrose/common/script/KotlinScript.kt
+++ b/script-utils-kotlin/src/main/kotlin/com/pambrose/common/script/KotlinScript.kt
@@ -51,7 +51,7 @@ class KotlinScript(
    */
   val varDecls: String
     get() {
-      val assigns = mutableListOf<String>()
+      val assigns: MutableList<String> = []
 
       valueMap
         .forEach { (name, value) ->

--- a/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/KotlinScriptTests.kt
+++ b/script-utils-kotlin/src/test/kotlin/com/pambrose/common/script/KotlinScriptTests.kt
@@ -116,7 +116,7 @@ class KotlinScriptTests : StringSpec() {
     }
 
     "object with types" {
-      val list = mutableListOf(1)
+      val list: MutableList<Int> = [1]
       val map = mutableMapOf("k1" to 1)
 
       KotlinScript().use {
@@ -148,7 +148,7 @@ class KotlinScriptTests : StringSpec() {
     }
 
     "object with KType" {
-      val list = mutableListOf(1)
+      val list: MutableList<Int> = [1]
 
       KotlinScript().use {
         it.apply {
@@ -172,7 +172,7 @@ class KotlinScriptTests : StringSpec() {
     }
 
     "null object" {
-      val list = mutableListOf<Int?>()
+      val list: MutableList<Int?> = []
 
       KotlinScript().use {
         it.apply {
@@ -232,7 +232,7 @@ class KotlinScriptTests : StringSpec() {
     }
 
     "unmatched params" {
-      val list = mutableListOf(1)
+      val list: MutableList<Int> = [1]
 
       KotlinScript().use { script ->
         shouldThrow<ScriptException> {
@@ -242,7 +242,7 @@ class KotlinScriptTests : StringSpec() {
     }
 
     "missing collection type" {
-      val list = mutableListOf(1)
+      val list: MutableList<Int> = [1]
 
       KotlinScript().use { script ->
         shouldThrow<ScriptException> { script.add("list", list) }

--- a/script-utils-python/src/test/kotlin/com/pambrose/common/script/PythonScriptTests.kt
+++ b/script-utils-python/src/test/kotlin/com/pambrose/common/script/PythonScriptTests.kt
@@ -106,7 +106,7 @@ class PythonScriptTests : StringSpec() {
     }
 
     "object with class" {
-      val list = mutableListOf(1)
+      val list: MutableList<Int> = [1]
       val map = mutableMapOf("k1" to 1)
 
       PythonScript().use {
@@ -144,7 +144,7 @@ class PythonScriptTests : StringSpec() {
     }
 
     "object with type" {
-      val list = mutableListOf(1)
+      val list: MutableList<Int> = [1]
 
       PythonScript().use {
         it.apply {
@@ -166,7 +166,7 @@ class PythonScriptTests : StringSpec() {
     }
 
     "null object" {
-      val list = mutableListOf<Int?>()
+      val list: MutableList<Int?> = []
 
       PythonScript().use {
         it.apply {

--- a/service-utils/src/main/kotlin/com/pambrose/common/service/AbstractGenericService.kt
+++ b/service-utils/src/main/kotlin/com/pambrose/common/service/AbstractGenericService.kt
@@ -70,7 +70,7 @@ abstract class AbstractGenericService<T> protected constructor(
   protected val startTime = Monotonic.markNow()
   protected val healthCheckRegistry = HealthCheckRegistry()
   protected val metricRegistry = MetricRegistry()
-  protected val services = mutableListOf<Service>()
+  protected val services: MutableList<Service> = []
 
   /** Whether admin endpoints are enabled, based on [AdminConfig.enabled]. */
   val isAdminEnabled = adminConfig.enabled

--- a/service-utils/src/test/kotlin/com/pambrose/common/service/GenericServiceTests.kt
+++ b/service-utils/src/test/kotlin/com/pambrose/common/service/GenericServiceTests.kt
@@ -149,7 +149,7 @@ class GenericServiceTests : StringSpec() {
     }
 
     "both variants register the same base health checks after init" {
-      val expected = listOf("all_services_healthy", "thread_deadlock")
+      val expected = ["all_services_healthy", "thread_deadlock"]
       TestJettyService().healthCheckNames shouldContainExactlyInAnyOrder expected
       TestKtorService().healthCheckNames shouldContainExactlyInAnyOrder expected
     }
@@ -177,7 +177,7 @@ class GenericServiceTests : StringSpec() {
 
       // The metrics_service check is registered only when metrics are enabled.
       service.healthCheckNames shouldContainExactlyInAnyOrder
-        listOf("all_services_healthy", "metrics_service", "thread_deadlock")
+        ["all_services_healthy", "metrics_service", "thread_deadlock"]
 
       // Before start, the sub-services are not yet running, so the aggregate check is unhealthy.
       service.runHealthChecks()["all_services_healthy"]?.isHealthy shouldBe false


### PR DESCRIPTION
## Summary

Adopts Kotlin 2.4's experimental collection-literal syntax (`[...]`) across every module (`src` and `test`), converting eligible `listOf(...)` and `mutableListOf(...)` call sites to the bracket form. `emptyList()` is intentionally left unchanged everywhere.

The change is **source-only and ABI-neutral** — `-Xcollection-literals` alters no published bytecode signature, so Maven Central consumers are unaffected.

## What changed

- **Build wiring** (`build.gradle.kts`): enable `-Xcollection-literals` on every compilation — JVM (`compileKotlin` + `compileTestKotlin`) and KMP (all targets, main + test).
- **`mutableListOf(...)` → `[...]`** (39 sites) with an explicit `MutableList<T>` on each variable declaration. This is load-bearing: without the explicit type a bare `[...]` infers `List` and silently drops mutability. The two annotation-free sites are genuine `MutableList` expected-type positions (map index-set / lambda return in `KtorServletResponse`).
- **`listOf(...)` → `[...]`** in main sources (9), JVM test sources (59), and KMP test sources (60).

## Deliberately skipped

- **All `emptyList()`** — out of scope; preserves the immutable `EmptyList` singleton on public-API default params (`ResendService.cc/bcc`, `SamplerGaugeCollector` labels, `RecaptchaService.errorCodes`).
- **6 `eval("...listOf...")` string-literal sites** in `KotlinScriptTests.kt` — Kotlin code passed *as strings* to a script evaluator, not compiled by the build.
- **5 `Any`-typed argument-position `mutableListOf` sites** in the script-utils tests — a literal there infers `List`, defeating the test's intent.
- **Gradle build scripts** other than root `build.gradle.kts` — compiled against Gradle's embedded Kotlin, which the flag doesn't reach.

## Notes

- The redis `ScanResult(pointer, listOf(...))` sites (Jedis, a Java constructor) were the [KT-80494](https://youtrack.jetbrains.com/issue/KT-80494) boundary case — they compiled fine, since passing a literal into a Java method parameter (seen as a Kotlin `List`) is allowed; only *constructing* a Java-defined collection type is blocked.
- **Experimental-flag risk:** `-Xcollection-literals` is experimental in Kotlin 2.4. A future Kotlin bump could change the syntax and require source revisiting — a deliberate, documented trade-off.

## Verification

`./gradlew build` + `make lint` pass across all modules and targets (JVM, JS, wasmJs, and native), with `emptyList()` unchanged at 21 occurrences repo-wide and the only `*.gradle.kts` touched being the root `build.gradle.kts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
