### PR TITLE
Document the 3.2.1 release and bump version to 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Common Utils are documented in this file.
 
+## [3.2.1] - 2026-07-25
+
+### Build & tooling
+
+- Adopt Kotlin 2.4 collection-literal syntax (`[...]`) across every module (`src` and `test`). Enable the
+  experimental `-Xcollection-literals` compiler flag on all JVM and KMP compilations (main and test), and
+  convert eligible `listOf(...)` and `mutableListOf(...)` call sites to bracket literals; each
+  `mutableListOf` conversion adds an explicit `MutableList<T>` on the variable, and `emptyList()` is left
+  unchanged. Source-only and ABI-neutral — no published signature changes.
+
+### Dependency bumps
+
+- `kover` 0.9.8 → 0.9.9
+- `grpc` 1.82.2 → 1.83.0
+- `kotest` 6.2.2 → 6.2.3
+- Bump project version to 3.2.1
+
 ## [3.2.0] - 2026-07-14
 
 ### Build & tooling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,11 @@ These opt-ins are enabled globally:
 - `kotlin.concurrent.atomics.ExperimentalAtomicApi`
 - `kotlinx.serialization.ExperimentalSerializationApi`
 
+Additionally, the experimental `-Xcollection-literals` compiler flag is enabled on every compilation
+(JVM and KMP, main and test) so `[...]` collection-literal syntax can be used in place of `listOf(...)` /
+`mutableListOf(...)`. The flag is experimental in Kotlin 2.4 and may need revisiting on a future Kotlin
+upgrade (if the syntax changes or the feature stabilizes and the flag can be dropped).
+
 ### Key Technologies
 
 - Kotlin 2.4.10 with JVM target 17 (KMP modules additionally target JS, wasmJs, and Native)
@@ -152,6 +157,6 @@ All modules use: `com.pambrose.common.*`
 
 ### Version Management
 
-- Project version: "3.2.0" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
+- Project version: "3.2.1" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
 - Group: "com.pambrose.common-utils" (set in `gradle.properties`)
 - All library versions in `gradle/libs.versions.toml`

--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ This library is available on [Maven Central](https://central.sonatype.com/artifa
 ```kotlin
 dependencies {
     // Include specific modules as needed
-  implementation("com.pambrose.common-utils:core-utils:3.2.0")
-  implementation("com.pambrose.common-utils:json-utils:3.2.0")
-  implementation("com.pambrose.common-utils:ktor-server-utils:3.2.0")
+  implementation("com.pambrose.common-utils:core-utils:3.2.1")
+  implementation("com.pambrose.common-utils:json-utils:3.2.1")
+  implementation("com.pambrose.common-utils:ktor-server-utils:3.2.1")
     // ... other modules
 }
 ```
@@ -222,7 +222,7 @@ root coordinate automatically. The JVM-only modules keep their plain artifact id
     <dependency>
         <groupId>com.pambrose.common-utils</groupId>
         <artifactId>core-utils-jvm</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1</version>
     </dependency>
     <!-- Add other modules as needed -->
 </dependencies>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,28 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
+## v3.2.1 — 2026-07-25
+
+### Highlights
+
+- **Collection literals**: adopt Kotlin 2.4's `[...]` collection-literal syntax across every module
+  (`src` and `test`). The experimental `-Xcollection-literals` compiler flag is enabled on all JVM and KMP
+  compilations (main and test), and eligible `listOf(...)` and `mutableListOf(...)` call sites are converted
+  to bracket literals — each `mutableListOf` conversion carries an explicit `MutableList<T>` on the variable,
+  and `emptyList()` is intentionally left unchanged. The change is source-only and ABI-neutral: no published
+  bytecode signature changes, so Maven Central consumers are unaffected. The flag is experimental in
+  Kotlin 2.4 and may require source revisiting on a future Kotlin bump.
+
+### Dependency bumps
+
+- `kover` 0.9.8 → 0.9.9
+- `grpc` 1.82.2 → 1.83.0
+- `kotest` 6.2.2 → 6.2.3
+
+**Full Changelog**: https://github.com/pambrose/common-utils/compare/3.2.0...3.2.1
+
+---
+
 ## v3.2.0 — 2026-07-14
 
 ### Highlights

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.pambrose.common-utils
-version=3.2.0
+version=3.2.1
 
 kotlin.code.style=official
 kotlin.native.ignoreDisabledTargets=true

--- a/llms.txt
+++ b/llms.txt
@@ -2,14 +2,14 @@
 
 > Modular Kotlin/Java utility libraries providing extension functions, DSLs, and helpers for common frameworks. Each module is independently consumable via Maven Central.
 
-- Version: 3.2.0
+- Version: 3.2.1
 - Group: com.pambrose.common-utils
 - Repository: https://github.com/pambrose/common-utils
 - Maven Central: https://central.sonatype.com/namespace/com.pambrose.common-utils
 - License: Apache 2.0
 - Kotlin: 2.4.10, JVM 17
 - Base package: com.pambrose.common.*
-- Install: `implementation("com.pambrose.common-utils:<module>:3.2.0")`
+- Install: `implementation("com.pambrose.common-utils:<module>:3.2.1")`
 - Multiplatform: core-utils, json-utils, and ktor-client-utils are Kotlin Multiplatform (JVM, JS, wasmJs,
   Native — iOS/macOS/tvOS/watchOS/Linux/Windows); all other modules are JVM-only
 - Maven (non-Gradle) consumers of the three multiplatform modules must use the `-jvm` artifact


### PR DESCRIPTION
## Summary

Documents the **3.2.1** release and bumps the project version `3.2.0` → `3.2.1`.

### Files updated
- `gradle.properties` — `version=3.2.1`
- `CHANGELOG.md` — new `[3.2.1]` entry
- `RELEASE_NOTES.md` — new `v3.2.1` entry with compare link
- `llms.txt` — version + install snippet
- `README.md` — Gradle/Maven install snippets
- `CLAUDE.md` — version reference, plus a note recording the experimental `-Xcollection-literals` flag under "Experimental Kotlin Features"

### What 3.2.1 covers (relative to 3.2.0)
- **Collection literals** — adoption of Kotlin 2.4's `[...]` syntax across all modules (`src` + `test`); `-Xcollection-literals` enabled on all JVM/KMP compilations; `emptyList()` left unchanged. Source-only and ABI-neutral. (Merged in #153.)
- **Dependency bumps** — kover 0.9.9, grpc 1.83.0, kotest 6.2.3. (From #154.)

## Note

The dependency-bump lines in the release docs describe the changes in #154, which must merge before the 3.2.1 tag is cut for the docs to be accurate. This PR is based on `master` at the collection-literals merge (`abe497b`); it touches only version/doc files, so it does not conflict with #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
