### PR TITLE
Replace remaining java.util.concurrent.atomic uses with kotlin.concurrent.atomics

### DIFF
--- a/core-utils/src/jvmMain/kotlin/com/pambrose/common/delegate/SingleAssignVar.kt
+++ b/core-utils/src/jvmMain/kotlin/com/pambrose/common/delegate/SingleAssignVar.kt
@@ -17,7 +17,7 @@
 
 package com.pambrose.common.delegate
 
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
@@ -32,7 +32,7 @@ object SingleAssignVar {
   fun <T> singleAssign(): ReadWriteProperty<Any?, T?> = ThreadSafeSingleAssignVar()
 
   private class ThreadSafeSingleAssignVar<T> : ReadWriteProperty<Any?, T?> {
-    private val atomicValue = AtomicReference<ValueHolder<T>?>()
+    private val atomicValue = AtomicReference<ValueHolder<T>?>(null)
 
     // Wrapper to distinguish between null value and unset value
     private data class ValueHolder<T>(
@@ -42,7 +42,7 @@ object SingleAssignVar {
     override fun getValue(
       thisRef: Any?,
       property: KProperty<*>,
-    ): T? = atomicValue.get()?.value
+    ): T? = atomicValue.load()?.value
 
     override fun setValue(
       thisRef: Any?,

--- a/redis-utils/src/test/kotlin/com/pambrose/common/redis/BugFixVerificationTests.kt
+++ b/redis-utils/src/test/kotlin/com/pambrose/common/redis/BugFixVerificationTests.kt
@@ -31,7 +31,8 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import redis.clients.jedis.exceptions.JedisConnectionException
 
 class BugFixVerificationTests : StringSpec() {
@@ -78,118 +79,118 @@ class BugFixVerificationTests : StringSpec() {
     val unreachableUrl = "redis://localhost:1"
 
     "withRedisPool: connection failure invokes block exactly once with null" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       val client = RedisUtils.newRedisClient(redisUrl = unreachableUrl, maxPoolSize = 1)
       try {
         val result =
           client.withRedisPool { c ->
-            callCount.incrementAndGet()
+            callCount.incrementAndFetch()
             c shouldBe null
             "from-null-branch"
           }
         result shouldBe "from-null-branch"
-        callCount.get() shouldBe 1
+        callCount.load() shouldBe 1
       } finally {
         client.close()
       }
     }
 
     "withNonNullRedisPool: connection failure returns null without invoking block" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       val client = RedisUtils.newRedisClient(redisUrl = unreachableUrl, maxPoolSize = 1)
       try {
         val result =
           client.withNonNullRedisPool { _ ->
-            callCount.incrementAndGet()
+            callCount.incrementAndFetch()
             "should-not-reach"
           }
         result shouldBe null
-        callCount.get() shouldBe 0
+        callCount.load() shouldBe 0
       } finally {
         client.close()
       }
     }
 
     "withSuspendingRedisPool: connection failure invokes block exactly once with null" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       val client = RedisUtils.newRedisClient(redisUrl = unreachableUrl, maxPoolSize = 1)
       try {
         val result =
           client.withSuspendingRedisPool { c ->
-            callCount.incrementAndGet()
+            callCount.incrementAndFetch()
             c shouldBe null
             "from-null-branch"
           }
         result shouldBe "from-null-branch"
-        callCount.get() shouldBe 1
+        callCount.load() shouldBe 1
       } finally {
         client.close()
       }
     }
 
     "withSuspendingNonNullRedisPool: connection failure returns null without invoking block" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       val client = RedisUtils.newRedisClient(redisUrl = unreachableUrl, maxPoolSize = 1)
       try {
         val result =
           client.withSuspendingNonNullRedisPool { _ ->
-            callCount.incrementAndGet()
+            callCount.incrementAndFetch()
             "should-not-reach"
           }
         result shouldBe null
-        callCount.get() shouldBe 0
+        callCount.load() shouldBe 0
       } finally {
         client.close()
       }
     }
 
     "withRedis: block JedisConnectionException propagates and block invoked once" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       shouldThrow<JedisConnectionException> {
         withRedis(redisUrl = unreachableUrl) { _ ->
-          callCount.incrementAndGet()
+          callCount.incrementAndFetch()
           throw JedisConnectionException("simulated mid-block failure")
         }
       }
-      callCount.get() shouldBe 1
+      callCount.load() shouldBe 1
     }
 
     "withNonNullRedis: block JedisConnectionException propagates and block invoked once" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       shouldThrow<JedisConnectionException> {
         withNonNullRedis(redisUrl = unreachableUrl) { _ ->
-          callCount.incrementAndGet()
+          callCount.incrementAndFetch()
           throw JedisConnectionException("simulated mid-block failure")
         }
       }
-      callCount.get() shouldBe 1
+      callCount.load() shouldBe 1
     }
 
     "withRedisPool: block exception from null branch propagates and block invoked once" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       val client = RedisUtils.newRedisClient(redisUrl = unreachableUrl, maxPoolSize = 1)
       try {
         shouldThrow<JedisConnectionException> {
           client.withRedisPool { _ ->
-            callCount.incrementAndGet()
+            callCount.incrementAndFetch()
             throw JedisConnectionException("simulated mid-block failure")
           }
         }
-        callCount.get() shouldBe 1
+        callCount.load() shouldBe 1
       } finally {
         client.close()
       }
     }
 
     "withSuspendingRedis: block JedisConnectionException propagates and block invoked once" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       shouldThrow<JedisConnectionException> {
         withSuspendingRedis(redisUrl = unreachableUrl) { _ ->
-          callCount.incrementAndGet()
+          callCount.incrementAndFetch()
           throw JedisConnectionException("simulated mid-block failure")
         }
       }
-      callCount.get() shouldBe 1
+      callCount.load() shouldBe 1
     }
   }
 }

--- a/redis-utils/src/test/kotlin/com/pambrose/common/redis/RedisUtilsMockTests.kt
+++ b/redis-utils/src/test/kotlin/com/pambrose/common/redis/RedisUtilsMockTests.kt
@@ -38,7 +38,8 @@ import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import java.time.Duration
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import redis.clients.jedis.RedisClient
 import redis.clients.jedis.UnifiedJedis
 import redis.clients.jedis.exceptions.JedisConnectionException
@@ -164,66 +165,66 @@ class RedisUtilsMockTests : StringSpec() {
     // private createRedisClient() factory on the RedisUtils object
 
     "withRedis passes null to block when client creation fails" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       failingCreateRedisClient()
       try {
         val result =
           withRedis(redisUrl = "redis://localhost:6379", printStackTrace = true) { c ->
-            callCount.incrementAndGet()
+            callCount.incrementAndFetch()
             c shouldBe null
             "created-null-branch"
           }
         result shouldBe "created-null-branch"
-        callCount.get() shouldBe 1
+        callCount.load() shouldBe 1
       } finally {
         unmockkObject(RedisUtils)
       }
     }
 
     "withNonNullRedis returns null without invoking block when client creation fails" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       failingCreateRedisClient()
       try {
         val result =
           withNonNullRedis(redisUrl = "redis://localhost:6379") { _ ->
-            callCount.incrementAndGet()
+            callCount.incrementAndFetch()
             "should-not-reach"
           }
         result shouldBe null
-        callCount.get() shouldBe 0
+        callCount.load() shouldBe 0
       } finally {
         unmockkObject(RedisUtils)
       }
     }
 
     "withSuspendingRedis passes null to block when client creation fails" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       failingCreateRedisClient()
       try {
         val result =
           withSuspendingRedis(redisUrl = "redis://localhost:6379") { c ->
-            callCount.incrementAndGet()
+            callCount.incrementAndFetch()
             c shouldBe null
             "suspending-null-branch"
           }
         result shouldBe "suspending-null-branch"
-        callCount.get() shouldBe 1
+        callCount.load() shouldBe 1
       } finally {
         unmockkObject(RedisUtils)
       }
     }
 
     "withSuspendingNonNullRedis returns null without invoking block when client creation fails" {
-      val callCount = AtomicInteger(0)
+      val callCount = AtomicInt(0)
       failingCreateRedisClient()
       try {
         val result =
           withSuspendingNonNullRedis(redisUrl = "redis://localhost:6379") { _ ->
-            callCount.incrementAndGet()
+            callCount.incrementAndFetch()
             "should-not-reach"
           }
         result shouldBe null
-        callCount.get() shouldBe 0
+        callCount.load() shouldBe 0
       } finally {
         unmockkObject(RedisUtils)
       }

--- a/service-utils/src/test/kotlin/com/pambrose/common/service/BugFixVerificationTests.kt
+++ b/service-utils/src/test/kotlin/com/pambrose/common/service/BugFixVerificationTests.kt
@@ -21,7 +21,7 @@ package com.pambrose.common.service
 import com.google.common.util.concurrent.AbstractIdleService
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicBoolean
 
 class BugFixVerificationTests : StringSpec() {
   init {
@@ -41,7 +41,7 @@ class BugFixVerificationTests : StringSpec() {
           override fun shutDown() {
             // Simulate some cleanup work
             Thread.sleep(100)
-            shutdownCompleted.set(true)
+            shutdownCompleted.store(true)
           }
         }
 
@@ -54,7 +54,7 @@ class BugFixVerificationTests : StringSpec() {
       thread.join(5000)
 
       // After the hook completes, the service should be fully terminated
-      shutdownCompleted.get() shouldBe true
+      shutdownCompleted.load() shouldBe true
       service.isRunning shouldBe false
     }
   }


### PR DESCRIPTION
## Summary

Converts the last four files still importing `java.util.concurrent.atomic` over to `kotlin.concurrent.atomics`, so the whole codebase uses one atomics API. `kotlin.concurrent.atomics.ExperimentalAtomicApi` is already a global opt-in, so no per-file annotations were needed.

| File | Change |
|---|---|
| `core-utils/src/jvmMain/.../SingleAssignVar.kt` | `AtomicReference<ValueHolder<T>?>()` → `AtomicReference<ValueHolder<T>?>(null)`, `.get()` → `.load()` |
| `redis-utils/src/test/.../BugFixVerificationTests.kt` | `AtomicInteger` → `AtomicInt`, `.incrementAndGet()` → `.incrementAndFetch()`, `.get()` → `.load()` |
| `redis-utils/src/test/.../RedisUtilsMockTests.kt` | same |
| `service-utils/src/test/.../BugFixVerificationTests.kt` | java `AtomicBoolean` → kotlin `AtomicBoolean`, `.set()`/`.get()` → `.store()`/`.load()` |

This matches the `.load()` / `.store()` / `compareAndSet()` idiom already used in `AtomicDelegates.kt`, `AtomicUtils.kt`, `BooleanMonitor.kt`, and `AbstractScript.kt`.

## Notes

- The Kotlin `AtomicReference` has no no-arg constructor, hence the explicit `(null)`. On the JVM these types are typealiases to the `java.util.concurrent.atomic` classes, so this is a source-level change with no runtime or ABI impact — `SingleAssignVar`'s public API is unchanged.
- `incrementAndFetch` is a package-level extension rather than a member (unlike `load`/`store`), so it needs its own `import kotlin.concurrent.atomics.incrementAndFetch`.

## Test plan

- `./gradlew :core-utils:compileKotlinJvm :redis-utils:compileTestKotlin :service-utils:compileTestKotlin` — passes
- `./gradlew :core-utils:jvmTest :redis-utils:test :service-utils:test lintKotlin` — passes
- `./gradlew :core-utils:detektJvmMain :redis-utils:detektTest :service-utils:detektTest` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)