### PR TITLE
Document the 3.2.2 release and bump version to 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to Common Utils are documented in this file.
 
+## [3.2.2] - 2026-07-31
+
+### Build & tooling
+
+- Replace the remaining `java.util.concurrent.atomic` uses with `kotlin.concurrent.atomics`, matching the
+  `load()`/`store()`/`compareAndSet()` idiom already used in `AtomicDelegates`, `AtomicUtils`,
+  `BooleanMonitor`, and `AbstractScript`. In core-utils' `SingleAssignVar`, `AtomicReference` now takes an
+  explicit `null` initial value (the Kotlin API has no no-arg constructor) and reads via `load()`; the
+  redis-utils and service-utils tests move to `AtomicInt`/`AtomicBoolean`. On the JVM these types are
+  typealiases to their Java counterparts, so the published API and runtime behavior are unchanged.
+- Move the ben-manes dependency-updates plugin id from `com.github.ben-manes.versions` to
+  `io.github.ben-manes.versions`, which is where the plugin is now published. Build-only — no effect on
+  consumers.
+
+### Dependency bumps
+
+- `grpc` 1.83.0 → 1.83.1
+- `ktor` 3.5.1 → 3.5.2
+- `gradlePlugins` 1.1.0 → 1.1.1 (build-only)
+- `versions` 0.54.0 → 0.57.0 (build-only)
+- `logback` 1.5.38 → 1.6.1 (test runtime only)
+- `h2` 2.3.232 → 2.4.240 (exposed-utils test scope only)
+- `mockk` 1.14.9 → 1.14.11 (test scope only)
+- Bump project version to 3.2.2
+
 ## [3.2.1] - 2026-07-25
 
 ### Build & tooling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Common behavior for testing and linting on the **JVM modules** is provided by [`
 
 The KMP modules apply the raw `org.jmailen.kotlinter` plugin instead (same reporters, configured inline in the root script) and declare their kotest/logback test dependencies explicitly in their own `build.gradle.kts` (versions pinned in the catalog to match the convention plugin).
 
-Dependency-update reporting uses the `com.github.ben-manes.versions` plugin, configured by the inline `configureVersions()`: its `isNonStable` filter rejects a pre-release candidate only when the current version is stable, so dependencies intentionally tracked on a pre-release line still surface updates.
+Dependency-update reporting uses the `io.github.ben-manes.versions` plugin (the id it publishes under as of 0.57.0; earlier releases used `com.github.ben-manes.versions`), configured by the inline `configureVersions()`: its `isNonStable` filter rejects a pre-release candidate only when the current version is stable, so dependencies intentionally tracked on a pre-release line still surface updates.
 
 Detekt is applied directly in the root `build.gradle.kts` via `configureDetekt()`. The aggregate `detekt` task depends on every per-source-set detekt task by type (`detektMain`/`detektTest` on JVM modules; `detektJvmMain`, `detektMetadataCommonMain`, etc. on KMP modules), so analysis runs with full type resolution. Optional shared config lives at `config/detekt/detekt.yml` and a shared suppression baseline at `config/detekt/baseline.xml` (both auto-detected if present).
 
@@ -116,6 +116,13 @@ Additionally, the experimental `-Xcollection-literals` compiler flag is enabled 
 (JVM and KMP, main and test) so `[...]` collection-literal syntax can be used in place of `listOf(...)` /
 `mutableListOf(...)`. The flag is experimental in Kotlin 2.4 and may need revisiting on a future Kotlin
 upgrade (if the syntax changes or the feature stabilizes and the flag can be dropped).
+
+Atomics come from `kotlin.concurrent.atomics` (`AtomicInt`, `AtomicLong`, `AtomicBoolean`,
+`AtomicReference`) everywhere — `src` and `test`, JVM-only modules included. Use the
+`load()`/`store()`/`compareAndSet()`/`incrementAndFetch()` idiom rather than the Java
+`get()`/`set()`/`incrementAndGet()` names, and note that `AtomicReference` has no no-arg constructor
+(pass an explicit `null`). Do not reintroduce `java.util.concurrent.atomic` imports; on the JVM the Kotlin
+types are typealiases to the Java ones, so there is nothing to gain from the Java API.
 
 ### Key Technologies
 
@@ -157,6 +164,6 @@ All modules use: `com.pambrose.common.*`
 
 ### Version Management
 
-- Project version: "3.2.1" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
+- Project version: "3.2.2" (set in `gradle.properties`; override at publish time with `-PoverrideVersion=...`, used by Makefile snapshot/publish targets)
 - Group: "com.pambrose.common-utils" (set in `gradle.properties`)
 - All library versions in `gradle/libs.versions.toml`

--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ This library is available on [Maven Central](https://central.sonatype.com/artifa
 ```kotlin
 dependencies {
     // Include specific modules as needed
-  implementation("com.pambrose.common-utils:core-utils:3.2.1")
-  implementation("com.pambrose.common-utils:json-utils:3.2.1")
-  implementation("com.pambrose.common-utils:ktor-server-utils:3.2.1")
+  implementation("com.pambrose.common-utils:core-utils:3.2.2")
+  implementation("com.pambrose.common-utils:json-utils:3.2.2")
+  implementation("com.pambrose.common-utils:ktor-server-utils:3.2.2")
     // ... other modules
 }
 ```
@@ -222,7 +222,7 @@ root coordinate automatically. The JVM-only modules keep their plain artifact id
     <dependency>
         <groupId>com.pambrose.common-utils</groupId>
         <artifactId>core-utils-jvm</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
     </dependency>
     <!-- Add other modules as needed -->
 </dependencies>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,33 @@ Release details are sourced from [GitHub Releases](https://github.com/pambrose/c
 
 ---
 
+## v3.2.2 — 2026-07-31
+
+### Highlights
+
+- **All-Kotlin atomics**: the last four files still using `java.util.concurrent.atomic` now use
+  `kotlin.concurrent.atomics`, so the whole codebase shares one atomics idiom
+  (`load()`/`store()`/`compareAndSet()`). core-utils' `SingleAssignVar` gives `AtomicReference` an explicit
+  `null` initial value and reads through `load()`; the redis-utils and service-utils tests switch to
+  `AtomicInt`/`AtomicBoolean`. On the JVM these Kotlin types are typealiases to their Java counterparts, so
+  the published API and runtime behavior are unchanged.
+- **Plugin id move**: the ben-manes dependency-updates plugin is applied as `io.github.ben-manes.versions`
+  (was `com.github.ben-manes.versions`), matching where it is published. Build-only.
+
+### Dependency bumps
+
+- `grpc` 1.83.0 → 1.83.1
+- `ktor` 3.5.1 → 3.5.2
+- `gradlePlugins` 1.1.0 → 1.1.1 (build-only)
+- `versions` 0.54.0 → 0.57.0 (build-only)
+- `logback` 1.5.38 → 1.6.1 (test runtime only)
+- `h2` 2.3.232 → 2.4.240 (exposed-utils test scope only)
+- `mockk` 1.14.9 → 1.14.11 (test scope only)
+
+**Full Changelog**: https://github.com/pambrose/common-utils/compare/3.2.1...3.2.2
+
+---
+
 ## v3.2.1 — 2026-07-25
 
 ### Highlights

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.pambrose.common-utils
-version=3.2.1
+version=3.2.2
 
 kotlin.code.style=official
 kotlin.native.ignoreDisabledTargets=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,11 +6,11 @@ jvmTarget = "17"
 # Plugins
 detekt = "2.0.0-alpha.5"
 dokka = "2.2.0"
-gradlePlugins = "1.1.0"
+gradlePlugins = "1.1.1"
 kotlinter = "5.5.0"
 kover = "0.9.9"
 mavenPublish = "0.37.0"
-versions = "0.54.0"
+versions = "0.57.0"
 
 # Kotlin & kotlinx
 kotlin = "2.4.10"
@@ -20,21 +20,21 @@ kotlinxHtml = "0.12.0"
 serialization = "1.11.0"
 
 # Logging
-logback = "1.5.38"
+logback = "1.6.1"
 logging = "8.0.4"
 
 # Frameworks
 dropwizard = "4.2.39"
-grpc = "1.83.0"
+grpc = "1.83.1"
 jakartaServlet = "6.1.0"
 jetty = "12.1.11"
-ktor = "3.5.1"
+ktor = "3.5.2"
 # Keep in sync with grpc
 tcnative = "2.0.75.Final"
 
 # Data
 exposed = "1.3.1"
-h2 = "2.3.232"
+h2 = "2.4.240"
 redis = "7.5.3"
 
 # Scripting
@@ -57,7 +57,7 @@ resend = "4.13.0"
 kotest = "6.2.3"
 # KSP versions independent of Kotlin since 2.3.0 (required by the kotest plugin)
 ksp = "2.3.9"
-mockk = "1.14.9"
+mockk = "1.14.11"
 
 [libraries]
 # Kotlin & kotlinx
@@ -181,7 +181,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
-ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "versions" }
+ben-manes-versions = { id = "io.github.ben-manes.versions", version.ref = "versions" }
 
 # Pambrose convention plugins
 pambrose-kotlinter = { id = "com.pambrose.kotlinter", version.ref = "gradlePlugins" }

--- a/llms.txt
+++ b/llms.txt
@@ -2,14 +2,14 @@
 
 > Modular Kotlin/Java utility libraries providing extension functions, DSLs, and helpers for common frameworks. Each module is independently consumable via Maven Central.
 
-- Version: 3.2.1
+- Version: 3.2.2
 - Group: com.pambrose.common-utils
 - Repository: https://github.com/pambrose/common-utils
 - Maven Central: https://central.sonatype.com/namespace/com.pambrose.common-utils
 - License: Apache 2.0
 - Kotlin: 2.4.10, JVM 17
 - Base package: com.pambrose.common.*
-- Install: `implementation("com.pambrose.common-utils:<module>:3.2.1")`
+- Install: `implementation("com.pambrose.common-utils:<module>:3.2.2")`
 - Multiplatform: core-utils, json-utils, and ktor-client-utils are Kotlin Multiplatform (JVM, JS, wasmJs,
   Native — iOS/macOS/tvOS/watchOS/Linux/Windows); all other modules are JVM-only
 - Maven (non-Gradle) consumers of the three multiplatform modules must use the `-jvm` artifact


### PR DESCRIPTION
## Summary

Prepares the 3.2.2 release (dated 2026-07-31).

- Bumps the project version 3.2.1 → 3.2.2 in `gradle.properties`, `llms.txt` (version line + install snippet), `README.md` (three Gradle snippets + Maven `<version>`), and `CLAUDE.md`.
- Adds the `3.2.2` entry to `CHANGELOG.md` and the `v3.2.2` entry to `RELEASE_NOTES.md`, covering the atomics migration (#156), the ben-manes plugin id move, and the dependency bumps below.
- Carries the pending dependency bumps that ship with this release.

## Dependency bumps

| Dependency | From | To | Scope |
| --- | --- | --- | --- |
| `grpc` | 1.83.0 | 1.83.1 | published |
| `ktor` | 3.5.1 | 3.5.2 | published |
| `gradlePlugins` | 1.1.0 | 1.1.1 | build-only |
| `versions` | 0.54.0 | 0.57.0 | build-only |
| `logback` | 1.5.38 | 1.6.1 | test runtime |
| `h2` | 2.3.232 | 2.4.240 | exposed-utils test |
| `mockk` | 1.14.9 | 1.14.11 | test |

## Build change

The ben-manes dependency-updates plugin id moves from `com.github.ben-manes.versions` to `io.github.ben-manes.versions` — the id it publishes under as of 0.57.0. Verified locally: `./gradlew help --task dependencyUpdates` reports the per-module tasks as `registered by plugin 'io.github.ben-manes.versions'`. `CLAUDE.md`'s build-configuration section is updated to match, and gains a note recording the `kotlin.concurrent.atomics` convention established by the atomics migration.

## Test plan

- [x] `./gradlew help` — build configures cleanly with the new plugin id
- [x] `./gradlew :core-utils:properties` reports `version: 3.2.2`
- [ ] CI `check` (lint + tests) — first run against logback 1.6.1, h2 2.4.240, ktor 3.5.2, and mockk 1.14.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)