### PR TITLE
Pin brace-expansion to 2.1.4 to close Dependabot DoS alert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,23 @@ types are typealiases to the Java ones, so there is nothing to gain from the Jav
 
 - `kotlin-js-store/` holds the Node/Yarn lockfiles for the JS and wasmJs toolchains; commit changes to it
   (run `./gradlew kotlinUpgradeYarnLock kotlinWasmUpgradeYarnLock` when JS dependencies change).
+- Vulnerable transitive npm packages are pinned through the `yarnResolutions` map in the root build script,
+  which feeds `YarnRootExtension.resolution(...)`. Gotchas when changing it:
+  - The map is **not** a tracked input to `rootPackageJson`, so that task stays `UP-TO-DATE` and reuses a
+    stale `build/js/package.json`. The upgrade tasks then re-resolve against the *old* resolutions and report
+    `BUILD SUCCESSFUL` while changing nothing. Always `rm -f build/js/package.json build/wasm/package.json`
+    first, then run the two upgrade tasks, then confirm the new pin actually landed — check the `resolutions`
+    block of the regenerated `build/js/package.json` and diff `kotlin-js-store/`. An empty lockfile diff
+    means the pin did not take, not that nothing needed fixing.
+  - A resolution only rewrites the lockfile when it changes the resolved version. yarn v1 will not re-resolve
+    an entry that still satisfies its range, so bumping a package already inside its requested range (the
+    usual shape of a CVE fix) requires the explicit pin — `kotlinUpgradeYarnLock` alone will not do it.
+  - The map is shared by both toolchains, so a pin for a package only one of them uses still adds a bare
+    pin-only entry (plus its transitives) to the other's lockfile. `diff`, `serialize-javascript`, and
+    `brace-expansion` are all pin-only entries in `kotlin-js-store/wasm/yarn.lock` — their presence there
+    does not mean the wasm toolchain actually pulls them in.
+- Verify JS/wasm toolchain changes with `./gradlew jsNodeTest --rerun wasmJsNodeTest --rerun`; without
+  `--rerun` these tasks report `UP-TO-DATE` and verify nothing.
 - `settings.gradle.kts` uses `FAIL_ON_PROJECT_REPOS` repositories mode with ivy repositories for the Node.js,
   Yarn, and Binaryen distributions; the root build script unsets every toolchain env spec's `downloadBaseUrl`
   (root and per-subproject) so the Kotlin plugin never registers project-level repositories.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,13 +107,16 @@ kover {
 }
 
 // Force patched versions of vulnerable transitive npm packages in the JS/wasmJs test
-// toolchains (Dependabot: ws DoS, serialize-javascript RCE/DoS, jsdiff DoS). The toolchain
-// requests them with pins/ranges that cannot reach the fixed versions on their own. After
-// changing these, re-run `./gradlew kotlinUpgradeYarnLock kotlinWasmUpgradeYarnLock`.
+// toolchains (Dependabot: ws DoS, serialize-javascript RCE/DoS, jsdiff DoS, brace-expansion
+// DoS). The toolchain requests them with pins/ranges that cannot reach the fixed versions on
+// their own — or, for brace-expansion, with a range that yarn will not re-resolve while the
+// lockfile already holds a satisfying-but-vulnerable entry. After changing these, re-run
+// `./gradlew kotlinUpgradeYarnLock kotlinWasmUpgradeYarnLock`.
 val yarnResolutions = mapOf(
     "ws" to "8.21.0",
     "serialize-javascript" to "7.0.5",
     "diff" to "8.0.3",
+    "brace-expansion" to "2.1.4",
 )
 
 // The settings script declares ivy repositories for the Node.js/Yarn/Binaryen distributions

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -7,6 +7,18 @@
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
   integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
 
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+brace-expansion@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
+  dependencies:
+    balanced-match "^1.0.0"
+
 diff@8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -56,10 +56,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-brace-expansion@^2.0.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
-  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
+brace-expansion@2.1.4, brace-expansion@^2.0.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
   dependencies:
     balanced-match "^1.0.0"
 


### PR DESCRIPTION
## Summary

Closes Dependabot alert #6 (high): [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — `brace-expansion` DoS via unbounded expansion length causing an out-of-memory process crash. `kotlin-js-store/yarn.lock` pinned 2.1.2, inside the vulnerable `>=2.0.0 <2.1.3` range.

**Impact is build-time only.** The package arrives as a transitive dependency of `minimatch` in the Kotlin/JS and wasmJs Node **test** toolchains. It is not part of any published Maven artifact, so there is no consumer exposure.

`./gradlew kotlinUpgradeYarnLock` alone does **not** fix this: yarn v1 will not re-resolve a lockfile entry that still satisfies its requested range, and 2.1.2 satisfies `minimatch`'s `^2.0.2`. The fix is an explicit pin via the existing `yarnResolutions` map, alongside `ws` / `serialize-javascript` / `diff`:

```kotlin
"brace-expansion" to "2.1.4",
```

2.1.4 is the head of the `maintenance-v2` line and satisfies `^2.0.2`, so it forces cleanly without the `incompatible with requested version` warning the other three pins emit.

### Why the wasm lockfile changed

The resolution map is shared by both toolchains, so pinning a package only the JS side uses still adds a bare pin-only entry (plus its `balanced-match` transitive) to `kotlin-js-store/wasm/yarn.lock`. The wasm toolchain does **not** request `brace-expansion`. This matches what is already there — `diff` and `serialize-javascript` are likewise pin-only entries in that file, whereas `ws` appears as `ws@8.20.1, ws@8.21.0` because wasm genuinely requests it. I kept the map shared rather than splitting it per-toolchain, since splitting adds build complexity to avoid two inert lines.

### CLAUDE.md

Documents three traps hit while applying this, each of which silently produces a false "it worked":

1. `yarnResolutions` is **not** a tracked input to `rootPackageJson`, so that task stays `UP-TO-DATE` and reuses a stale generated `package.json`. The upgrade tasks then re-resolve against the *old* resolutions and report `BUILD SUCCESSFUL` while changing nothing. `rm -f build/js/package.json build/wasm/package.json` first.
2. `jsNodeTest` / `wasmJsNodeTest` report `UP-TO-DATE` and verify nothing without `--rerun`.
3. Pin-only entries in the wasm lockfile do not imply the wasm toolchain uses the package.

## Test plan

- [x] Both generated `package.json` files carry the pin; `build/js/node_modules/brace-expansion` resolves 2.1.4
- [x] `kotlin-js-store/yarn.lock` entry is `brace-expansion@2.1.4, brace-expansion@^2.0.2: version "2.1.4"` — out of the vulnerable range
- [x] All six `jsNodeTest` / `wasmJsNodeTest` tasks pass under `--rerun` (verified on this branch's master baseline, not just on top of the Gradle 9.7.0 bump)
- [x] Re-resolving on the master baseline produces no further lockfile drift
- [ ] CI green

Independent of #158 (Gradle 9.7.0 + dependency bumps); branched from `master`, so the two can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)