### PR TITLE
Pin js-yaml to 4.3.1 to close Dependabot DoS alert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,9 @@ types are typealiases to the Java ones, so there is nothing to gain from the Jav
     an entry that still satisfies its range, so bumping a package already inside its requested range (the
     usual shape of a CVE fix) requires the explicit pin — `kotlinUpgradeYarnLock` alone will not do it.
   - The map is shared by both toolchains, so a pin for a package only one of them uses still adds a bare
-    pin-only entry (plus its transitives) to the other's lockfile. `diff`, `serialize-javascript`, and
-    `brace-expansion` are all pin-only entries in `kotlin-js-store/wasm/yarn.lock` — their presence there
-    does not mean the wasm toolchain actually pulls them in.
+    pin-only entry (plus its transitives) to the other's lockfile. `diff`, `serialize-javascript`,
+    `brace-expansion`, and `js-yaml` are all pin-only entries in `kotlin-js-store/wasm/yarn.lock` — their
+    presence there does not mean the wasm toolchain actually pulls them in.
 - Verify JS/wasm toolchain changes with `./gradlew jsNodeTest --rerun wasmJsNodeTest --rerun`; without
   `--rerun` these tasks report `UP-TO-DATE` and verify nothing.
 - `settings.gradle.kts` uses `FAIL_ON_PROJECT_REPOS` repositories mode with ivy repositories for the Node.js,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,15 +108,17 @@ kover {
 
 // Force patched versions of vulnerable transitive npm packages in the JS/wasmJs test
 // toolchains (Dependabot: ws DoS, serialize-javascript RCE/DoS, jsdiff DoS, brace-expansion
-// DoS). The toolchain requests them with pins/ranges that cannot reach the fixed versions on
-// their own — or, for brace-expansion, with a range that yarn will not re-resolve while the
-// lockfile already holds a satisfying-but-vulnerable entry. After changing these, re-run
-// `./gradlew kotlinUpgradeYarnLock kotlinWasmUpgradeYarnLock`.
+// DoS, js-yaml DoS). The toolchain requests them with pins/ranges that cannot reach the fixed
+// versions on their own — or, for brace-expansion and js-yaml, with a range that yarn will not
+// re-resolve while the lockfile already holds a satisfying-but-vulnerable entry. See the
+// "Kotlin Multiplatform Notes" section of CLAUDE.md for the procedure when changing these; the
+// upgrade tasks silently no-op unless the generated package.json files are deleted first.
 val yarnResolutions = mapOf(
     "ws" to "8.21.0",
     "serialize-javascript" to "7.0.5",
     "diff" to "8.0.3",
     "brace-expansion" to "2.1.4",
+    "js-yaml" to "4.3.1",
 )
 
 // The settings script declares ivy repositories for the Node.js/Yarn/Binaryen distributions

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
   integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -23,6 +28,13 @@ diff@8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.3.tgz#c7da3d9e0e8c283bb548681f8d7174653720c2d5"
   integrity sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==
+
+js-yaml@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
+  dependencies:
+    argparse "^2.0.1"
 
 serialize-javascript@7.0.5:
   version "7.0.5"

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -252,10 +252,10 @@ jackspeak@^3.1.2:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
-js-yaml@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@4.3.1, js-yaml@^4.1.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary

Closes Dependabot alert #7 (high): [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU consumption in js-yaml's `!!omap` resolution, with the CVE-2026-59870 fix not backported to 3.x/4.x. `kotlin-js-store/yarn.lock` pinned 4.3.0, inside the vulnerable `>=4.0.0 <4.3.1` range.

**Impact is build-time only.** js-yaml arrives as a transitive dependency of `mocha` in the Kotlin/JS and wasmJs Node **test** toolchains. It is not part of any published Maven artifact, so there is no consumer exposure. The lockfile entry predates this branch — the alert is new because the advisory was only just published, and Dependabot surfaced it when it rescanned `master` after #159 merged.

Same mechanism as #159: `./gradlew kotlinUpgradeYarnLock` alone does **not** fix this, because 4.3.0 satisfies mocha's `^4.1.0` and yarn v1 will not re-resolve a lockfile entry that still satisfies its range. The fix is an explicit `yarnResolutions` pin:

```kotlin
"js-yaml" to "4.3.1",
```

4.3.1 is the head of the `v4-legacy` line and satisfies `^4.1.0`, so it forces cleanly with no `incompatible with requested version` warning.

## Why not just bump mocha?

Checked, and it would not help. The Kotlin plugin pins mocha at exactly 11.7.5, and **mocha 11.8.0 requests byte-identical ranges** for every package involved:

| Pin | mocha's range | Reachable without a pin? |
|---|---|---|
| `diff` 8.0.3 | `^7.0.0` | Never — major boundary |
| `serialize-javascript` 7.0.5 | `^6.0.2` | Never — major boundary |
| `js-yaml` 4.3.1 | `^4.1.0` | In range, but yarn won't re-resolve |
| `brace-expansion` 2.1.4 | `^2.0.2` (via minimatch) | In range, but yarn won't re-resolve |
| `ws` 8.21.0 | n/a — Kotlin's own dep, pinned 8.20.1 | Exact pin upstream |

The two major-boundary rows are why three `incompatible with requested version` warnings appear during `kotlinNpmInstall` — expected, not misconfiguration. There is no upstream fix to wait for, so future advisories in mocha's dependency tree will each need the same treatment.

## Note on the wasm lockfile

As documented in CLAUDE.md, the resolution map is shared, so pinning a package only the JS side uses adds a bare pin-only entry plus its transitives (`argparse`) to `kotlin-js-store/wasm/yarn.lock`. The wasm toolchain does not request js-yaml. This PR adds `js-yaml` to that documented list to keep it accurate.

## Test plan

- [x] Pin reached both generated `package.json` files (`build/js`, `build/wasm`)
- [x] JS lock entry is `js-yaml@4.3.1, js-yaml@^4.1.0: version "4.3.1"` — out of the vulnerable range
- [x] `build/js/node_modules/js-yaml` installs 4.3.1
- [x] `make tests` green: `BUILD SUCCESSFUL`, 550/550 tasks executed, 19 module `check` tasks, all 6 `jsNodeTest`/`wasmJsNodeTest` tasks, `0 failed` — mocha runs fine on 4.3.1
- [x] No lockfile drift on re-resolve
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)